### PR TITLE
Improve Conan version overriding

### DIFF
--- a/Makefile.all
+++ b/Makefile.all
@@ -29,34 +29,6 @@ SUBMAKEFLAGS += -j${NPROC}
 endif
 endif
 
-## VENDOR_ONLY
-##   Usage: make VENDOR_ONLY=1 export
-##   Default: 0
-##
-##   This is somewhat of a misleading option, since it may imply that vendor
-##   packages are normally selected, which they are not. This is mainly useful
-##   for exporting the vendor recipes should they not already be available
-##   through an Artifactory or Conan server.
-##
-VENDOR_ONLY := 0
-
-## RECURSIVE
-##   Usage: make RECURSIVE=1 SELECT_PKGS="pkg1 ..." <targets>
-##   Default: 0
-##
-##   If set to 1, you can specify with SELECT_PKG a single package, but the
-##   dependencies will also be included. This allows us to do the following:
-##
-##       make RECURSIVE=1 SELECT_PKGS="engine" purge editable clean all
-##
-##   This command would then build engine with all its dependencies in-source,
-##   which is useful when making changes to, say fable and engine at the same
-##   time.
-##
-##   Note that this bypasses UNSELECT_PGKS, which is why it is off by default.
-##
-RECURSIVE := 0
-
 ## UNSELECT_PKGS
 ##   Usage: make UNSELECT_PKGS="pkg1 pkg2 ..." <targets>
 ##   Default: ""
@@ -65,9 +37,6 @@ RECURSIVE := 0
 ##   This should only be provided from the command line, for example:
 ##
 ##       make UNSELECT_PKGS="plugins/vtd plugins/demo_printer" package
-##
-##   Note that if RECURSIVE=1, then it is not possible to unselect packages
-##   that are depended upon by selected packages.
 ##
 UNSELECT_PKGS :=
 
@@ -79,6 +48,14 @@ UNSELECT_PKGS :=
 ##   overrides UNSELECT_PKG.
 ##
 SELECT_PKGS :=
+
+## BUILD_POLICY
+##   Usage: make BUILD_POLICY="outdated"
+##   Default: "missing"
+##
+##   This variable contains the default Conan build policy for package targets.
+##
+BUILD_POLICY := missing
 
 ## CONAN_OPTIONS
 ##   Usage: make CONAN_OPTIONS="..."
@@ -122,7 +99,6 @@ BUILD_TESTS := 1
 # --------------------------------------------------------------------------- #
 
 # Define all packages with their dependencies:
-# - Ensure RECURSIVE=1 works.
 # - Ensure USE_NPROC=1 works.
 # - Ensure packages are built in correct order.
 ALL_VENDOR_PKGS := $(wildcard vendor/*)
@@ -131,6 +107,19 @@ ALL_ENGINE_PKGS := oak engine
 ALL_PLUGIN_PKGS := $(wildcard plugins/*)
 ALL_PKGS := ${ALL_RUNTIME_PKGS} ${ALL_ENGINE_PKGS} ${ALL_PLUGIN_PKGS} cloe
 .PHONY: ${ALL_VENDOR_PKGS} ${ALL_PKGS}
+
+REGEX_TARGET := 's/(-vendor|-select)?-each//'
+$(filter-out cloe, ${ALL_PKGS} ${ALL_VENDOR_PKGS}):
+	${MAKE} -C $@ $(shell echo ${MAKECMDGOALS} | sed -re ${REGEX_TARGET})
+
+# Re-define cloe target to use Makefile.package, and only run for targets
+# where it makes sense, since "cloe" is a Conan meta-package.
+cloe:
+	for case in export package package-outdated list purge clean; do \
+		if [[ "$$(echo '${MAKECMDGOALS}' | sed -re ${REGEX_TARGET})" == "$${case}" ]]; then \
+			${MAKE} -f Makefile.package CONAN_OPTIONS="${CONAN_OPTIONS}" $${case}; \
+		fi \
+	done
 
 fable:
 runtime: fable
@@ -141,17 +130,8 @@ ${ALL_PLUGIN_PKGS}: runtime models
 
 # Select packages to use:
 # - Define recipes only for selected packages.
-# - Ensure RECURSIVE=1 works.
 # - Ensure CONAN_OPTIONS are correct for cloe metapackage.
 # - SELECT_PKGS contains final list of selected packages.
-ifeq (${VENDOR_ONLY},1)
-ALL_PKGS := ${ALL_VENDOR_PKGS}
-endif
-
-ifeq (${RECURSIVE},1)
-$(filter-out cloe, ${ALL_PKGS}):
-	${MAKE} -C $@ $(shell echo ${MAKECMDGOALS} | sed -re 's/-all//')
-endif
 
 ifeq (${WITH_ENGINE},0)
 ALL_PKGS := $(filter-out oak, ${ALL_PKGS})
@@ -180,78 +160,103 @@ CONAN_OPTIONS += -o cloe-plugin-basic:test=False
 endif
 
 SELECT_PKGS := $(filter-out ${UNSELECT_PKGS}, ${ALL_PKGS})
-ifeq (${RECURSIVE},0)
-$(filter-out cloe, ${SELECT_PKGS}):
-	${MAKE} -C $@ $(shell echo ${MAKECMDGOALS} | sed -re 's/-all//')
-endif
 
-define make_rule
+define make_target_help
 help::
-	@printf "  % -16s to %s\n" ${1} ${2}
+	@printf "  % -20s to %s\n" ${1} ${2}
+endef
 
-${1}-all: ${SELECT_PKGS}
+define make_target_rule
 ${1}:
 	@printf "________________________________________"
 	@printf "________________________________________\n"
-	@printf ":: Proceeding to%s\n" "$(shell echo "${2}" | sed -re 's/ +/ /g')"
-	${MAKE} ${SUBMAKEFLAGS} ${1}-all
+	@printf ":: Proceeding to%s\n" "$(shell echo "${3}" | sed -re 's/ +/ /g')"
+	${MAKE} ${SUBMAKEFLAGS} ${4} ${2}
 endef
 
-define make_target
-$(eval $(call make_rule,${1},${2}))
+define make_target_rules
+$(call make_target_help,${1},${2})
+$(call make_target_rule,${1},${1}-each,${2},)
+${1}-each: ${3}
 endef
 
-# Re-define cloe target to use Makefile.package, and only run for targets
-# where it makes sense, since "cloe" is a Conan meta-package.
-cloe:
-	for case in export package package-outdated list purge clean; do \
-		if [[ "${MAKECMDGOALS}" == "$${case}-all" ]]; then \
-			${MAKE} -f Makefile.package CONAN_OPTIONS="${CONAN_OPTIONS}" $${case}; \
-		fi \
-	done
+define make_vendor_target
+$(eval $(call make_target_rules,${1},${2},${ALL_VENDOR_PKGS}))
+endef
+
+define make_every_target
+$(eval $(call make_target_rules,${1},${2},${ALL_PKGS}))
+endef
+
+define make_select_target
+$(eval $(call make_target_rules,${1},${2},${SELECT_PKGS}))
+endef
+
+define make_cloe_rules
+$(call make_target_help,${1},${2})
+$(call make_target_rule,${1},${1},${2},-f Makefile.package CONAN_OPTIONS="${CONAN_OPTIONS}")
+endef
+
+define make_cloe_target
+$(eval $(call make_cloe_rules,${1},${2}))
+endef
+
+# --------------------------------------------------------------------------- #
 
 .PHONY: help
 .DEFAULT: help
 .SILENT: help
 help::
-	echo "Available package targets:"
+	echo "Available build targets:"
 
-$(call make_target, export,           "export selected package recipes      [conan-cache]")
-$(call make_target, package,          "create selected packages             [conan-cache]")
-$(call make_target, package-outdated, "create selected packages if outdated [conan-cache]")
-$(call make_target, list,             "list selected package install files  [conan-cache]")
-$(call make_target, purge,            "remove selected packages from cache  [conan-cache]")
+$(call make_vendor_target, export-vendor,      "export all vendor packages                  [conan-cache]")
+$(call make_vendor_target, package-vendor,     "create all vendor packages                  [conan-cache]")
 
 help::
 	echo
 
-$(call make_target, editable,         "instruct Conan to use in-source build for selected packages")
-$(call make_target, uneditable,       "instruct Conan to use local cache for selected packages")
+$(call make_every_target, export,              "export all package recipes                  [conan-cache]")
+$(call make_cloe_target, package,              "create cloe package with build policy       [conan-cache]")
+$(call make_cloe_target, package-all,          "create cloe package and all dependencies    [conan-cache]")
+$(call make_cloe_target, package-outdated,     "create cloe package if outdated             [conan-cache]")
 
 help::
 	echo
 
-$(call make_target, all,              "build selected packages                [in-source]")
-$(call make_target, conan,            "configure Conan and get dependencies   [in-source]")
-$(call make_target, configure,        "configure CMake packages               [in-source]")
-$(call make_target, test,             "run CMake tests if they are available  [in-source]")
-$(call make_target, export-pkg,       "export build artifacts to Conan cache  [in-source]")
-$(call make_target, clean,            "remove build artifacts                 [in-source]")
+$(call make_select_target, export-select,      "export selected packages                    [conan-cache]")
+$(call make_select_target, package-select,     "create selected packages with policy        [conan-cache]")
+$(call make_select_target, list-select,        "list selected package install files         [conan-cache]")
+$(call make_select_target, purge-select,       "remove selected packages from cache         [conan-cache]")
+
+help::
+	echo
+
+$(call make_select_target, editable-select,    "toggle [in-source] build for selected packages")
+$(call make_select_target, uneditable-select,  "toggle [conan-cache] build for selected packages")
+
+help::
+	echo
+
+$(call make_select_target, all-select,         "build selected packages                     [in-source]")
+$(call make_select_target, conan-select,       "configure Conan and get dependencies        [in-source]")
+$(call make_select_target, configure-select,   "configure CMake packages                    [in-source]")
+$(call make_select_target, test-select,        "run CMake tests if they are available       [in-source]")
+$(call make_select_target, export-pkg-select,  "export build artifacts to Conan cache       [in-source]")
+$(call make_select_target, clean-select,       "remove build artifacts                      [in-source]")
 
 help::
 	echo
 	echo "  Options:"
-	echo "    USE_NPROC=(0|1)     to build $(shell nproc) packages simultaneously (default=0)"
-	echo "    RECURSIVE=(0|1)     to recursively select dependent packages (default=0)"
-	echo "    VENDOR_ONLY=(0|1)   to only select vendor packages (default=0)"
-	echo "    WITH_ENGINE=(0|1)   to build and deploy cloe-engine (default=1)"
-	echo "    WITH_VTD=(0|1)      to build and deploy cloe-plugin-vtd (default=1)"
-	echo "    BUILD_TESTS=(0|1)   to build and run unit tests (default=1)"
+	echo "    USE_NPROC=(0|1)    to build $(shell nproc) packages simultaneously (default=0)"
+	echo "    WITH_ENGINE=(0|1)  to build and deploy cloe-engine (default=1)"
+	echo "    WITH_VTD=(0|1)     to build and deploy cloe-plugin-vtd (default=1)"
+	echo "    BUILD_TESTS=(0|1)  to build and run unit tests (default=1)"
 	echo
 	echo "  Defines:"
-	echo "    CONAN_OPTIONS = ${CONAN_OPTIONS}"
-	echo "    UNSELECT_PKGS = ${UNSELECT_PKGS}"
-	echo "    SELECT_PKGS   = \\"
+	echo "    BUILD_POLICY:  ${BUILD_POLICY}"
+	echo "    CONAN_OPTIONS: ${CONAN_OPTIONS}"
+	echo "    UNSELECT_PKGS: ${UNSELECT_PKGS}"
+	echo "    SELECT_PKGS:   \\"
 	echo "$$(echo "      ${SELECT_PKGS}" | fmt -70)"
 	echo
 	echo "  Please see Makefile.all for more details and usage tips."

--- a/Makefile.package
+++ b/Makefile.package
@@ -72,7 +72,8 @@ help:
 	echo "  help        to show this help"
 	echo
 	echo "  export            to export recipe and sources        [conan-cache]"
-	echo "  package           to create package                   [conan-cache]"
+	echo "  package           to create package with build policy [conan-cache]"
+	echo "  package-all       to create package and dependencies  [conan-cache]"
 	echo "  package-outdated  to create package if outdated       [conan-cache]"
 	echo "  list              to list installed package files     [conan-cache]"
 	echo "  purge             to remove package from cache        [conan-cache]"
@@ -90,6 +91,7 @@ help:
 	echo "Configuration:"
 	echo "  SOURCE_DIR:      ${SOURCE_DIR}"
 	echo "  BUILD_DIR:       ${BUILD_DIR}"
+	echo "  BUILD_POLICY:    ${BUILD_POLICY}"
 	echo "  CONAN_OPTIONS:   ${CONAN_OPTIONS}"
 	echo
 	echo "Package information:"
@@ -125,7 +127,7 @@ uneditable:
 	conan editable remove ${PACKAGE_FQN}
 
 # CONAN TARGETS ---------------------------------------------------------------
-.PHONY: export package package-outdated purge list
+.PHONY: export package package-all package-missing package-outdated purge list
 
 export:
 	# Export sources to Conan cache.
@@ -138,10 +140,20 @@ export:
 package:
 	# Build the package in Conan cache unconditionally.
 	#
-	#   Conan will retrieve (and build, if necessary) any missing dependencies.
+	#   Conan will retrieve and build all dependencies based on the build policy.
 	#   Note that this cannot be called if the package is currently in editable mode.
 	#
+	#   See: https://docs.conan.io/en/latest/mastering/policies.html
+	#
 	conan create . ${PACKAGE_CHANNEL} --build=${BUILD_POLICY} --build=${PACKAGE_NAME} ${CONAN_OPTIONS}
+
+package-all:
+	# Build the package in Conan cache unconditionally.
+	#
+	#   Conan will retrieve and build all dependencies unconditionally.
+	#   Note that this cannot be called if the package is currently in editable mode.
+	#
+	conan create . ${PACKAGE_CHANNEL} --build ${CONAN_OPTIONS}
 
 package-outdated:
 	# Build the package in Conan cache if it is outdated.

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ backfiring with increased support issues.
 Getting Started
 ---------------
 
-For building, deploying, and running the runtime and engine we use
-[Conan](https://conan.io), a modern C++ package manager. We currently have not
-published any Conan packages that can be downloaded directly.
-Building them yourself is pretty straightforward.
+For building, deploying, and running the runtime and engine we use [Conan][1],
+a modern C++ package manager. We currently have not published any Conan
+packages that can be downloaded directly. Building them yourself is pretty
+straightforward.
 
-Currently, we only support Linux or WSL.
+Currently, we only support Linux or [WSL][2].
 
 ### Installing Dependencies
 
-We provide automatic dependency installation for Ubuntu und Archlinux
+We provide automatic dependency installation for [Ubuntu][3] und [Archlinux][4]
 via the `Makefile.setup` Makefile. You should inspect it before
 running the targets, as these will modify your system.
 Other distributions may work, if the packages are available.
@@ -52,22 +52,16 @@ You may need to setup your Conan profile before continuing on to the next
 point. In a pinch, the following steps should suffice:
 
  1. Install Conan with Python.
-    ```console
-    $ pip3 install --user --upgrade conan
-    Collecting conan
-    ...
-    Successfully built conan
-    Installing collected packages: conan
-      Attempting uninstall: conan
-        Found existing installation: conan 1.28.1
-        Uninstalling conan-1.28.1:
-          Successfully uninstalled conan-1.28.1
-    Successfully installed conan-1.29.0
+    ```
+    pip3 install --user --upgrade conan
     ```
  2. Define a Conan profile, which defines the machine configuration.
+    ```
+    conan profile new --detect default
+    conan profile update settings.compiler.libcxx=libstdc++11 default
+    ```
+    If everything works out, your Conan profile should look something like this.
     ```console
-    $ conan profile new --detect default
-    $ conan profile update settings.compiler.libcxx=libstdc++11 default
     $ conan profile show default
     Configuration for profile default:
     [settings]
@@ -81,23 +75,30 @@ point. In a pinch, the following steps should suffice:
       build_type       = Release
     ```
 
-See the Conan documentation for more information on how to do this.
+3. Increase the request timeout to work around performance [issues][5] with the
+   Conan Center.
+   ```
+   conan config set general.request_timeout=360
+   ```
+See the Conan [documentation][6] for more information on how to do this.
 
 ### Building the Cloe Packages
 
 To build all packages, you should run the following:
 
-    make export VENDOR_ONLY=1
+    make export-vendor export
     make package
 
-This will export Conan recipes for some of our dependencies and build the
-packages that are contained in the repository. If you want to make use of
-all your 64 CPU cores, you can run the last command like so:
-
-    make package USE_NPROC=1
-
-For more details on how this is done, have a look at the Makefiles in the
-repository root.
+This will export all Conan recipes from this repository and create the cloe
+package. Conan will download and build all necessary dependencies. Should
+any errors occur during the build, you may have to force Conan to build
+all packages instead of re-using packages it finds:
+```
+    make package-all
+```
+Run `make help` to get an overview of the available targets we expect you to
+use. For more details on how this is done, have a look at the Makefiles in the
+repository root or the Dockerfiles in `dist/docker` directory.
 
 ### Running Cloe
 
@@ -141,3 +142,10 @@ Once the `cloe-launch` tool is available, you can do one of the following:
     Cloe 0.18.0-nightly (2020-10-01)
     ...
     ```
+
+[1]: https://conan.io
+[2]: https://docs.microsoft.com/en-us/windows/wsl/about
+[3]: https://ubuntu.com
+[4]: https://archlinux.org
+[5]: https://github.com/conan-io/conan-center-index/issues/950
+[6]: https://docs.conan.io/en/latest/

--- a/dist/docker/Dockerfile.alpine
+++ b/dist/docker/Dockerfile.alpine
@@ -25,6 +25,7 @@ RUN apk add \
       linux-headers \
       make \
       musl-dev \
+      perl \
       py3-pip \
     && \
     rm -rf /var/cache/apk/*
@@ -37,15 +38,16 @@ RUN pip3 install --upgrade pip && \
     python3 -m pip install conan && \
     conan profile new --detect default && \
     conan profile update settings.compiler.libcxx=libstdc++11 default && \
+    conan config set general.request_timeout=360 && \
     conan remote clean && \
     conan remote add default ${CONAN_REMOTE} ${CONAN_REMOTE_VERIFY_SSL}
 
 # Build and Install Cloe
 WORKDIR /cloe
 COPY . /cloe
-RUN make VENDOR_ONLY=1 export && \
-    make BUILD_TESTS=0 WITH_ENGINE=0 WITH_VTD=0 package && \
-    make BUILD_TESTS=0 WITH_ENGINE=0 WITH_VTD=0 INSTALL_DIR="/deploy" deploy && \
+RUN make export-vendor export && \
+    make WITH_VTD=0 package-all && \
+    make WITH_VTD=0 INSTALL_DIR="/deploy" deploy && \
     conan remove \* -b -f
 
 # Finalize Image

--- a/dist/docker/Dockerfile.archlinux
+++ b/dist/docker/Dockerfile.archlinux
@@ -26,14 +26,15 @@ ARG CONAN_REMOTE=https://conan.bintray.com
 ARG CONAN_REMOTE_VERIFY_SSL=true
 RUN conan profile new --detect default && \
     conan profile update settings.compiler.libcxx=libstdc++11 default && \
+    conan config set general.request_timeout=360 && \
     conan remote clean && \
     conan remote add default ${CONAN_REMOTE} ${CONAN_REMOTE_VERIFY_SSL}
 
 # Build and Install Cloe
 WORKDIR /cloe
 COPY . /cloe
-RUN make VENDOR_ONLY=1 export && \
-    make WITH_VTD=0 package && \
+RUN make export-vtd export && \
+    make WITH_VTD=0 package-all && \
     make WITH_VTD=0 INSTALL_DIR="/deploy" deploy && \
     conan remove \* -b -f
 

--- a/dist/docker/Dockerfile.ubuntu
+++ b/dist/docker/Dockerfile.ubuntu
@@ -38,6 +38,7 @@ ARG CONAN_REMOTE=https://conan.bintray.com
 ARG CONAN_REMOTE_VERIFY_SSL=true
 RUN conan profile new --detect default && \
     conan profile update settings.compiler.libcxx=libstdc++11 default && \
+    conan config set general.request_timeout=360 && \
     conan remote clean && \
     conan remote add default ${CONAN_REMOTE} ${CONAN_REMOTE_VERIFY_SSL}
 
@@ -51,12 +52,12 @@ COPY . /cloe
 RUN \
     # Export our own Conan recipes, in case they are not available in the
     # CONAN_REMOTE specified above.
-    make VENDOR_ONLY=1 export && \
+    make export-vendor export && \
     # Build all the packages, except for vtd, because that currently requires
     # dependencies we don't have in the Docker container.
     # You can specify more than one package here, see the Makefile for more
     # information on the WITH_*, PACKAGES, NOBUILD_PKGS, and BUILD_PKGS variables.
-    make WITH_VTD=0 package && \
+    make WITH_VTD=0 package-all && \
     # Deploy all the Cloe packages to INSTALL_DIR, which is /usr/local by
     # default. This will also populate BUILD_DIR, so that should be removed
     # afterwards to prevent this image from getting too big.

--- a/fable/conanfile.py
+++ b/fable/conanfile.py
@@ -28,7 +28,7 @@ class Fable(ConanFile):
         "CMakeLists.txt",
     ]
     requires = [
-        "boost/[~=1.69.0]",
+        "boost/[>=1.65.1]",
         "fmt/[~=6.2.0]",
         "nlohmann_json/[~=3.9.1]",
     ]

--- a/models/conanfile.py
+++ b/models/conanfile.py
@@ -28,7 +28,7 @@ class CloeModels(ConanFile):
         "CMakeLists.txt",
     ]
     requires = [
-        "boost/[>=1.69]",
+        "boost/[>=1.65.1]",
         "eigen/[~=3.3.7]",
     ]
 

--- a/plugins/vtd/conanfile.py
+++ b/plugins/vtd/conanfile.py
@@ -26,7 +26,6 @@ class CloeSimulatorVTD(ConanFile):
     ]
     no_copy_source = True
     build_requires = [
-        "boost/[~=1.69.0]",
         "open-simulation-interface/3.2.0@cloe/stable",
     ]
 

--- a/runtime/conanfile.py
+++ b/runtime/conanfile.py
@@ -29,7 +29,7 @@ class CloeRuntime(ConanFile):
         "CMakeLists.txt",
     ]
     requires = [
-        "boost/1.69.0",
+        "boost/[>=1.65.1]",
         "inja/[~=3.0.0]",
         "spdlog/[~=1.5.0]",
         "incbin/[~=1.74.0]@cloe/stable",

--- a/vendor/cpp-netlib/conanfile.py
+++ b/vendor/cpp-netlib/conanfile.py
@@ -20,7 +20,7 @@ class CppNetlib(ConanFile):
     generators = "cmake"
     requires = [
         # CppNetlib does not work with a boost that is newer than 1.69
-        "boost/1.69.0",
+        "boost/[>=1.65.0 <1.70]",
         "openssl/1.1.1g",
     ]
 


### PR DESCRIPTION
This PR does a few things:

1. It makes it easier to override *boost* by being less specific on which versions we need.
2. Refactor `Makefile.all` and `Makefile.package` to let Conan build the requirements by default.

This changes the way we build cloe by default a little, but I think it's for the better:

Before, it would look like something like this:
```bash
make VENDOR_ONLY=1 export
make export
make -f Makefile.package package
```

After this PR:
```bash
make export-vendor export package
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eclipse/cloe/5)
<!-- Reviewable:end -->
