### PR TITLE
Support fusion components

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -55,6 +55,7 @@ if(BuildTests)
     target_link_libraries(${test-libstack}
         CONAN_PKG::gtest
         CONAN_PKG::boost
+        CONAN_PKG::cloe-models
         ${libstack}
     )
     gtest_add_tests(TARGET ${test-libstack})

--- a/engine/src/simulation.cpp
+++ b/engine/src/simulation.cpp
@@ -478,19 +478,21 @@ StateId SimulationMachine::Connect::impl(SimulationContext& ctx) {
      */
     auto new_component = [&ctx](cloe::Vehicle& v,
                                 const cloe::ComponentConf& c) -> std::shared_ptr<cloe::Component> {
+      // Create a copy of the component factory prototype and initialize it with the default stack arguments.
       auto f = c.factory->clone();
       auto name = c.name.value_or(c.binding);
       for (auto d : ctx.config.get_component_defaults(name, f->name())) {
         f->from_conf(d.args);
       }
-      std::shared_ptr<cloe::Component> from;
-      if (c.from) {
-        if (v.has(*c.from)) {
-          from = v.get<cloe::Component>(*c.from);
-        } else {
+      // Get input components, if applicable.
+      std::vector<std::shared_ptr<cloe::Component>> from;
+      for (const auto& from_comp_name : c.from) {
+        if (!v.has(from_comp_name)) {
           return nullptr;
         }
+        from.push_back(v.get<cloe::Component>(from_comp_name));
       }
+      // Create the new component.
       auto x = f->make(c.args, std::move(from));
       ctx.now_initializing = x.get();
 
@@ -578,12 +580,17 @@ StateId SimulationMachine::Connect::impl(SimulationContext& ctx) {
 
             // We now have a component that has not been configured, and this
             // can only be the case if the dependency is not found.
-            assert(kv.second.from);
-            throw cloe::ModelError{
-                "cannot configure component '{}': cannot resolve dependency '{}'",
-                kv.first,
-                *kv.second.from,
-            };
+            assert(kv.second.from.size() > 0);
+            for (const auto& from_comp_name : kv.second.from) {
+              if (x->has(from_comp_name)) {
+                continue;
+              }
+              throw cloe::ModelError{
+                  "cannot configure component '{}': cannot resolve dependency '{}'",
+                  kv.first,
+                  from_comp_name,
+              };
+            }
           }
         }
       }

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -119,7 +119,11 @@ ControllerSchema::ControllerSchema() {
 ComponentSchema::ComponentSchema() {
   this->set_transform_schema([](fable::schema::Struct&& s) -> fable::schema::Box {
     s.set_property("name", id_prototype("globally unique identifier for component"));
-    s.set_property("from", make_prototype<std::string>("component input for binding"));
+    s.set_property("from",
+                   fable::schema::Variant{
+                       make_prototype<std::string>("component input for binding"),
+                       make_prototype<std::vector<std::string>>("component inputs for binding"),
+                   });
     return s;
   });
 }

--- a/engine/src/stack_test.cpp
+++ b/engine/src/stack_test.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <cloe/component.hpp>                // for DEFINE_COMPONENT_FACTORY
+#include <cloe/component/ego_sensor.hpp>     // for EgoSensor
 #include <cloe/component/object_sensor.hpp>  // for ObjectSensor
 #include <cloe/core.hpp>                     // for Json
 #include <fable/utility/gtest.hpp>           // for assert_from_conf
@@ -35,11 +36,9 @@ using namespace cloe;                        // NOLINT(build/namespaces)
 TEST(cloe_stack, serialization_of_empty_stack) {
   Stack s;
 
-  fable::assert_from_conf(s, R"(
-    {
-      "version": "4"
-    }
-  )");
+  fable::assert_from_conf(s, R"({
+    "version": "4"
+  })");
 
   Json expect = R"({
     "engine": {
@@ -120,19 +119,17 @@ TEST(cloe_stack, serialization_of_empty_stack) {
 TEST(cloe_stack, serialization_with_logging) {
   Stack s;
 
-  assert_from_conf(s, R"(
-    {
-      "version": "4",
-      "defaults": {
-        "simulators": [
-          { "binding": "vtd", "args": { "label_vehicle": "symbol" } }
-        ]
-      },
-      "logging": [
-        { "name": "*", "level": "info" }
+  assert_from_conf(s, R"({
+    "version": "4",
+    "defaults": {
+      "simulators": [
+        { "binding": "vtd", "args": { "label_vehicle": "symbol" } }
       ]
-    }
-  )");
+    },
+    "logging": [
+      { "name": "*", "level": "info" }
+    ]
+  })");
 
   Json expect = R"({
     "engine": {
@@ -249,25 +246,96 @@ DEFINE_COMPONENT_FACTORY(DummySensorFactory, DummySensorConf, "dummy_object_sens
 DEFINE_COMPONENT_FACTORY_MAKE(DummySensorFactory, DummySensor, cloe::ObjectSensor)
 
 TEST(cloe_stack, deserialization_of_component) {
-  {
-    std::shared_ptr<DummySensorFactory> cf = std::make_shared<DummySensorFactory>();
-    ComponentConf cc = ComponentConf("dummy_sensor", cf);
-    // Create a sensor component from the given configuration.
-    fable::assert_from_conf(cc, R"(
-      {
-        "binding": "dummy_sensor",
-        "name": "my_dummy_sensor",
-        "from": "some_obj_sensor",
-        "args" : {
-          "freq" : 9
-        }
-      }
-    )");
-    // In production code, "some_obj_sensor" would be fetched from a list of all
-    // available sensors. Skip this step here.
-    std::shared_ptr<cloe::Component> from = std::shared_ptr<cloe::NopObjectSensor>();
-    auto d = std::dynamic_pointer_cast<DummySensor>(
-        std::shared_ptr<cloe::Component>(std::move(cf->make(cc.args, from))));
-    ASSERT_EQ(d->get_freq(), 9);
+  // Create a sensor component from the given configuration.
+  std::shared_ptr<DummySensorFactory> cf = std::make_shared<DummySensorFactory>();
+  ComponentConf cc = ComponentConf("dummy_sensor", cf);
+  fable::assert_from_conf(cc, R"({
+    "binding": "dummy_sensor",
+    "name": "my_dummy_sensor",
+    "from": "some_obj_sensor",
+    "args" : {
+      "freq" : 9
+    }
+  })");
+
+  // In production code, "some_obj_sensor" would be fetched from a list of all
+  // available sensors. Skip this step here.
+  std::vector<std::shared_ptr<cloe::Component>> from = {std::shared_ptr<cloe::NopObjectSensor>()};
+  auto d = std::dynamic_pointer_cast<DummySensor>(
+      std::shared_ptr<cloe::Component>(std::move(cf->make(cc.args, from))));
+  ASSERT_EQ(d->get_freq(), 9);
+}
+
+class FusionSensor : public NopObjectSensor {
+ public:
+  FusionSensor(const std::string& name, const DummySensorConf& conf,
+               std::vector<std::shared_ptr<ObjectSensor>> obj_sensors,
+               std::shared_ptr<EgoSensor> ego_sensor)
+      : NopObjectSensor(), config_(conf), obj_sensors_(obj_sensors), ego_sensor_(ego_sensor) {}
+
+  virtual ~FusionSensor() noexcept = default;
+
+  uint64_t get_freq() const { return config_.freq; }
+
+ private:
+  DummySensorConf config_;
+  std::vector<std::shared_ptr<ObjectSensor>> obj_sensors_;
+  std::shared_ptr<EgoSensor> ego_sensor_;
+};
+
+DEFINE_COMPONENT_FACTORY(FusionSensorFactory, DummySensorConf, "fusion_object_sensor",
+                         "test component config")
+
+std::unique_ptr<::cloe::Component> FusionSensorFactory::make(
+    const ::cloe::Conf& c, std::vector<std::shared_ptr<cloe::Component>> comp_src) const {
+  decltype(config_) conf{config_};
+  if (!c->is_null()) {
+    conf.from_conf(c);
   }
+  std::vector<std::shared_ptr<ObjectSensor>> obj_sensors;
+  std::vector<std::shared_ptr<EgoSensor>> ego_sensors;
+  for (auto& comp : comp_src) {
+    auto obj_s = std::dynamic_pointer_cast<ObjectSensor>(comp);
+    if (obj_s != nullptr) {
+      obj_sensors.push_back(obj_s);
+      continue;
+    }
+    auto ego_s = std::dynamic_pointer_cast<EgoSensor>(comp);
+    if (ego_s != nullptr) {
+      ego_sensors.push_back(ego_s);
+      continue;
+    }
+    throw Error("FusionSensorFactory: Source component type not supported: from {}", comp->name());
+  }
+  if (ego_sensors.size() != 1) {
+    throw Error("FusionSensorFactory: {}: Require exactly one ego sensor.", this->name());
+  }
+  return std::make_unique<FusionSensor>(this->name(), conf, obj_sensors, ego_sensors.front());
+}
+
+TEST(cloe_stack, deserialization_of_fusion_component) {
+  // Create a sensor component from the given configuration.
+  std::shared_ptr<FusionSensorFactory> cf = std::make_shared<FusionSensorFactory>();
+  ComponentConf cc = ComponentConf("fusion_object_sensor", cf);
+  fable::assert_from_conf(cc, R"({
+    "binding": "fusion_object_sensor",
+    "name": "my_fusion_sensor",
+    "from": [
+      "ego_sensor0",
+      "obj_sensor1",
+      "obj_sensor2"
+    ],
+    "args" : {
+      "freq" : 77
+    }
+  })");
+
+  // In production code, a component list containing "ego_sensor0", ... would
+  // be generated. Skip this step here.
+  std::vector<std::shared_ptr<cloe::Component>> sensor_subset = {
+      std::make_shared<cloe::NopEgoSensor>(), std::make_shared<cloe::NopObjectSensor>(),
+      std::make_shared<cloe::NopObjectSensor>()};
+  auto f = std::dynamic_pointer_cast<FusionSensor>(
+      std::shared_ptr<cloe::Component>(std::move(cf->make(cc.args, sensor_subset))));
+  ASSERT_EQ(f->get_freq(), 77);
 }

--- a/fable/CMakeLists.txt
+++ b/fable/CMakeLists.txt
@@ -50,6 +50,7 @@ if(BuildTests)
         # find src -type f -name "*_test.cpp"
         src/fable/environment_test.cpp
         src/fable/schema/const_test.cpp
+        src/fable/schema/custom_test.cpp
         src/fable/schema/enum_test.cpp
         src/fable/schema/factory_test.cpp
         src/fable/schema/factory_advanced_test.cpp

--- a/fable/include/fable/schema/array.hpp
+++ b/fable/include/fable/schema/array.hpp
@@ -104,7 +104,7 @@ class Array : public Base<Array<T, P>> {
       j["minItems"] = min_items_;
     }
     if (max_items_ != std::numeric_limits<size_t>::max()) {
-      j["maxitems"] = max_items_;
+      j["maxItems"] = max_items_;
     }
     this->augment_schema(j);
     return j;

--- a/fable/include/fable/schema/custom.hpp
+++ b/fable/include/fable/schema/custom.hpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file fable/schema/custom.hpp
+ * \see  fable/schema/custom_test.cpp
+ * \see  fable/schema/variant.hpp
+ */
+
+#pragma once
+#ifndef FABLE_SCHEMA_CUSTOM_HPP_
+#define FABLE_SCHEMA_CUSTOM_HPP_
+
+#include <functional>  // for function<>
+
+#include <fable/schema/interface.hpp>  // for Interface, Box
+
+namespace fable {
+namespace schema {
+
+/**
+ * The CustomDeserializer allows the user to replace the deserialization of a
+ * Schema with a custom function.
+ *
+ * This is especially useful for schema types such as Variants.
+ *
+ * Note that if you use this, you may have to define to_json yourself.
+ */
+class CustomDeserializer : public schema::Interface {
+ public:  // Constructors
+  CustomDeserializer(Box&& s) : impl_(std::move(s).reset_pointer().get()) {}
+  CustomDeserializer(Box&& s, std::function<void(CustomDeserializer*, const Conf&)> f)
+      : impl_(std::move(s).reset_pointer().get()), from_conf_fn_(f) {}
+
+ public:  // Special
+  operator Box() const { return Box{this->clone()}; }
+
+  void set_from_conf(std::function<void(CustomDeserializer*, const Conf&)> f) { from_conf_fn_ = f; }
+
+  CustomDeserializer with_from_conf(std::function<void(CustomDeserializer*, const Conf&)> f) && {
+    set_from_conf(f);
+    return std::move(*this);
+  }
+
+ public:  // Overrides
+  Interface* clone() const override { return new CustomDeserializer(*this); }
+
+  using Interface::to_json;
+  JsonType type() const override { return impl_->type(); }
+  std::string type_string() const override { return impl_->type_string(); }
+  bool is_required() const override { return impl_->is_required(); }
+  const std::string& description() const override { return impl_->description(); }
+  void set_description(const std::string& s) override { return impl_->set_description(s); }
+  Json usage() const override { return impl_->usage(); }
+  Json json_schema() const override { return impl_->json_schema(); };
+  void validate(const Conf& c) const override { impl_->validate(c); }
+  void to_json(Json& j) const override { impl_->to_json(j); }
+
+  void from_conf(const Conf& c) override {
+    if (!from_conf_fn_) {
+      throw Error("no deserializer configured");
+    }
+    from_conf_fn_(this, c);
+  }
+
+  void reset_ptr() override {
+    impl_->reset_ptr();
+    from_conf_fn_ = [](CustomDeserializer*, const Conf&) {
+      throw Error("cannot deserialize after reset_ptr is called");
+    };
+  }
+
+  friend void to_json(Json& j, const CustomDeserializer& b) { b.impl_->to_json(j); }
+
+ private:
+  std::shared_ptr<schema::Interface> impl_{nullptr};
+  std::function<void(CustomDeserializer*, const Conf&)> from_conf_fn_{};
+};
+
+}  // namespace schema
+}  // namespace fable
+
+#endif  // FABLE_SCHEMA_CUSTOM_HPP_

--- a/fable/include/fable/schema/interface.hpp
+++ b/fable/include/fable/schema/interface.hpp
@@ -272,6 +272,11 @@ class Box : public Interface {
 
  public:  // Special
   /**
+   * Return the underlying Interface.
+   */
+  std::shared_ptr<Interface> get() { return impl_; }
+
+  /**
    * Return this type as a pointer to T.
    *
    * This method can be used like so:
@@ -315,6 +320,11 @@ class Box : public Interface {
   template <typename T>
   std::shared_ptr<T> as_unsafe() const {
     return std::dynamic_pointer_cast<T>(impl_);
+  }
+
+  Box reset_pointer() && {
+    reset_ptr();
+    return std::move(*this);
   }
 
  public:  // Overrides

--- a/fable/src/fable/schema/custom_test.cpp
+++ b/fable/src/fable/schema/custom_test.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file fable/schema/custom_test.cpp
+ * \see  fable/schema/custom.hpp
+ */
+
+#include <string>  // for string
+#include <vector>  // for vector<>
+
+#include <gtest/gtest.h>  // for TEST
+
+#include <fable/confable.hpp>       // for Confable
+#include <fable/schema.hpp>         // for Schema, Variant, Conf, Json
+#include <fable/schema/custom.hpp>  // for CustomDeserializer
+#include <fable/utility/gtest.hpp>  // for assert_from_conf
+
+namespace {
+
+/**
+ * MyCustomStruct models a command that can take either a string which it
+ * passes to a shell to run, or an array, which it runs directly.
+ *
+ * It needs to make use of CustomDeserializer for this to work.
+ * We dispense with the error checking that would be required in production
+ * code, since this is just a unit test.
+ */
+struct MyCustomStruct : public fable::Confable {
+  std::string executable;
+  std::vector<std::string> args;
+
+  CONFABLE_SCHEMA(MyCustomStruct) {
+    // clang-format off
+    using namespace fable;
+    using namespace fable::schema;  // NOLINT(build/namespaces)
+    return Struct{
+        {"command", Variant{
+            "system command to execute",
+            // Variant #1: system command to pass to a shell
+            {
+              CustomDeserializer(
+                  make_prototype<std::string>(),
+                  [this](CustomDeserializer*, const Conf& c) {
+                    this->executable = "/bin/bash";
+                    this->args = {"-c", c.get<std::string>()};
+                  }
+              ),
+              // Variant #2: an array with the first element the command to run
+              // and the rest of the items the arguments to the command.
+              CustomDeserializer(
+                  make_prototype<std::vector<std::string>>().min_items(1),
+                  [this](CustomDeserializer*, const Conf& c) {
+                    auto args = c.get<std::vector<std::string>>();
+                    this->executable = args[0];
+                    for (size_t i = 1; i < args.size(); ++i) {
+                      this->args.push_back(args[i]);
+                    }
+                  }
+              ),
+            },
+        }.require()}
+    };
+    // clang-format on
+  }
+
+  void to_json(fable::Json& j) const override {
+    j = fable::Json{
+        {"executable", executable},
+        {"args", args},
+    };
+  }
+};
+
+}  // anonymous namespace
+
+TEST(fable_schema_custom, schema) {
+  MyCustomStruct tmp;
+  fable::assert_schema_eq(tmp, R"({
+    "type": "object",
+    "properties": {
+      "command": {
+        "description": "system command to execute",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        ]
+      }
+    },
+    "required": ["command"],
+    "additionalProperties": false
+  })");
+}
+
+TEST(fable_schema_custom, from_conf) {
+  MyCustomStruct tmp;
+
+  fable::assert_from_conf(tmp, R"({
+    "command": "echo 'Hello World'"
+  })");
+  ASSERT_EQ(tmp.executable, "/bin/bash");
+
+  fable::assert_from_conf(tmp, R"({
+    "command": ["echo", "Hello World!"]
+  })");
+  ASSERT_EQ(tmp.executable, "echo");
+
+  fable::assert_invalidate(tmp, R"({
+    "command": []
+  })");
+  ASSERT_EQ(tmp.executable, "echo");
+}
+
+TEST(fable_schema_custom, to_json) {
+  MyCustomStruct tmp;
+  tmp.executable = "echo";
+  tmp.args = {"Hello World"};
+  fable::assert_to_json(tmp, R"({
+    "executable": "echo",
+    "args": ["Hello World"]
+  })");
+}


### PR DESCRIPTION
This PR extends the configuration of vehicle components. Previously, a single input (source) component was supported for each component, which is now extended to multiple input components of different derived type.

Resolves #9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eclipse/cloe/17)
<!-- Reviewable:end -->
