### PR TITLE
tooling: Override boost dependency in cloe-engine

### DIFF
--- a/Makefile.all
+++ b/Makefile.all
@@ -50,12 +50,12 @@ UNSELECT_PKGS :=
 SELECT_PKGS :=
 
 ## BUILD_POLICY
-##   Usage: make BUILD_POLICY="outdated"
-##   Default: "missing"
+##   Usage: make BUILD_POLICY="missing"
+##   Default: "outdated"
 ##
 ##   This variable contains the default Conan build policy for package targets.
 ##
-BUILD_POLICY := missing
+BUILD_POLICY := outdated
 
 ## CONAN_OPTIONS
 ##   Usage: make CONAN_OPTIONS="..."

--- a/conanfile.py
+++ b/conanfile.py
@@ -37,6 +37,7 @@ class Cloe(ConanFile):
         self.requires("{}/{}@cloe/develop".format(name, self.version))
 
     def requirements(self):
+        self.requires("boost/[<1.70]", override=True)
         requires = [
             "cloe-runtime",
             "cloe-models",

--- a/engine/conanfile.py
+++ b/engine/conanfile.py
@@ -23,9 +23,6 @@ class CloeEngine(ConanFile):
         "webui/*",
         "CMakeLists.txt",
     ]
-    build_requires = [
-        "cli11/1.9.1",
-    ]
 
     _cmake = None
 
@@ -36,10 +33,13 @@ class CloeEngine(ConanFile):
     def set_version(self):
         self.version = self._project_version()
 
+    def requirements(self):
+        self.requires("cloe-runtime/{}@cloe/develop".format(self.version))
+        self.requires("cloe-models/{}@cloe/develop".format(self.version))
+        self.requires("cloe-oak/{}@cloe/develop".format(self.version), private=True)
+        self.requires("cli11/1.9.1", private=True),
+
     def build_requirements(self):
-        self.build_requires("cloe-runtime/{}@cloe/develop".format(self.version))
-        self.build_requires("cloe-models/{}@cloe/develop".format(self.version))
-        self.build_requires("cloe-oak/{}@cloe/develop".format(self.version))
         if self.options.test:
             self.build_requires("gtest/[~1.10]")
 

--- a/plugins/vtd/conanfile.py
+++ b/plugins/vtd/conanfile.py
@@ -27,8 +27,6 @@ class CloeSimulatorVTD(ConanFile):
     no_copy_source = True
     requires = [
         "vtd/2.2.0@cloe/stable",
-    ]
-    build_requires = [
         "open-simulation-interface/3.2.0@cloe/stable",
         "vtd-api/2.2.0@cloe/stable",
     ]


### PR DESCRIPTION
An option was added to the `cloe-engine` package that allows to specify a boost version (range). In order to overwrite the boost dependency for all upstream packages, `cloe-engine`'s `build_requirements` dependencies needed to be replaced by [private](https://docs.conan.io/en/latest/reference/conanfile/methods.html#requirements) `requirements`. 
With this change, the same boost version is used for all upstream dependencies:

`conan info  -g graph.out engine/ | grep boost`
`conan info -o boost_version=1.65.1 -g graph.out engine/ | grep boost`

Resolves #20.