### PR TITLE
fable: Relax version fmt version requirement

### DIFF
--- a/fable/conanfile.py
+++ b/fable/conanfile.py
@@ -28,7 +28,7 @@ class Fable(ConanFile):
     ]
     requires = [
         "boost/[>=1.65.1]",
-        "fmt/[~=6.2.0]",
+        "fmt/[>=6.2.0]",
         "nlohmann_json/[~=3.9.1]",
     ]
 

--- a/runtime/conanfile.py
+++ b/runtime/conanfile.py
@@ -33,7 +33,7 @@ class CloeRuntime(ConanFile):
     requires = [
         "boost/[>=1.65.1]",
         "inja/[~=3.0.0]",
-        "spdlog/[~=1.5.0]",
+        "spdlog/[~=1.9.0]",
         "incbin/[~=1.74.0]@cloe/stable",
     ]
 


### PR DESCRIPTION
Fable was designed to be an independently usable library for
configuration de/serialization and validation. As a library it should
be as flexible as possible regarding its dependencies. Therefore
the requirement was relaxed to >=6.2.0.

Resolves #50.

A simple `make export-vendor package-auto` was successful, but more thorough compatibility tests may be worthwhile.