### PR TITLE
vendor: Fix cpp-netlib package recipe

### DIFF
--- a/vendor/cpp-netlib/CMakeLists.txt
+++ b/vendor/cpp-netlib/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.7)
+
+project(cpp-netlib
+    LANGUAGES CXX
+)
+
+include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(NO_OUTPUT_DIRS)
+
+conan_set_find_paths()
+conan_set_find_library_paths()
+
+add_subdirectory(cpp-netlib)

--- a/vendor/cpp-netlib/conanfile.py
+++ b/vendor/cpp-netlib/conanfile.py
@@ -17,6 +17,9 @@ class CppNetlib(ConanFile):
     default_options = {
         "shared": False,
     }
+    exports_sources = [
+        "CMakeLists.txt",
+    ]
     generators = "cmake"
     requires = [
         # CppNetlib does not work with a boost that is newer than 1.69
@@ -42,7 +45,8 @@ class CppNetlib(ConanFile):
         self._cmake.definitions["CPP-NETLIB_ENABLE_HTTPS"] = True
         self._cmake.definitions["CPP-NETLIB_STATIC_BOOST"] = True
         self._cmake.definitions["CPP-NETLIB_STATIC_OPENSSL"] = True
-        self._cmake.configure(source_folder=self._source_folder)
+        self._cmake.definitions["Boost_NO_BOOST_CMAKE"] = True
+        self._cmake.configure()
         return self._cmake
 
     def build(self):


### PR DESCRIPTION
It turned out that the previous build recipe lead to incompatible boost versions being used if those were installed as system libraries.