### PR TITLE
Prepare actuator model integration

### DIFF
--- a/models/include/cloe/component/ego_sensor.hpp
+++ b/models/include/cloe/component/ego_sensor.hpp
@@ -50,10 +50,25 @@ class EgoSensor : public Component {
   virtual double wheel_steering_angle() const = 0;
 
   /**
+   * Return the requested longitudinal acceleration in m/s2.
+   */
+  virtual double driver_request_acceleration() const = 0;
+
+  /**
+   * Return the requested front left wheel steering angle in radians.
+   */
+  virtual double driver_request_wheel_steering_angle() const = 0;
+
+  /**
    * Return the speed of the steering wheel rotation in radians/s.
    *
    * Positive values indicate clockwise rotation from the perspective of the
    * driver.
+   *
+   * FIXME(tobias): the way this is implemented in the vtd plugin is not
+   * consistent with what the function name/documentation suggests. Instead of
+   * the steering wheel speed, the driver-requested steering speed at the front
+   * wheels is returned. Either change the interface or the implementation.
    */
   virtual double steering_wheel_speed() const = 0;
 
@@ -78,16 +93,21 @@ class NopEgoSensor : public EgoSensor {
   virtual ~NopEgoSensor() noexcept = default;
   const Object& sensed_state() const override { return obj_; }
   double wheel_steering_angle() const override { return angle_; }
-  double steering_wheel_speed() const override { return steering_wheel_speed_; }
+  double driver_request_acceleration() const override { return driver_req_accel_; }
+  double driver_request_wheel_steering_angle() const override { return driver_req_angle_; }
+  virtual double steering_wheel_speed() const { return steering_wheel_speed_; }
   void reset() override {
     obj_ = Object{};
     angle_ = 0.0;
+    driver_req_angle_ = 0.0;
     steering_wheel_speed_ = 0.0;
   }
 
  protected:
   Object obj_{};
   double angle_{0.0};
+  double driver_req_accel_{0.0};
+  double driver_req_angle_{0.0};
   double steering_wheel_speed_{0.0};
 };
 

--- a/models/include/cloe/component/latlong_actuator.hpp
+++ b/models/include/cloe/component/latlong_actuator.hpp
@@ -44,7 +44,7 @@ class LatLongActuator : public Component {
    * Set the vehicle target acceleration in m/s^2.
    * The time that the vehicle requires to reach this acceleration is undefined.
    */
-  void set_acceleration(double a) {
+  virtual void set_acceleration(double a) {
     target_acceleration_ = a;
     level_.set_long();
   }
@@ -62,7 +62,7 @@ class LatLongActuator : public Component {
    * In most cases, the front left wheel defines the angle, and the time to target
    * steering angle is zero.
    */
-  void set_steering_angle(double a) {
+  virtual void set_steering_angle(double a) {
     target_steering_angle_ = a;
     level_.set_lat();
   }

--- a/models/include/cloe/component/latlong_actuator.hpp
+++ b/models/include/cloe/component/latlong_actuator.hpp
@@ -166,6 +166,8 @@ class LatLongActuator : public Component {
   utility::ActuationLevel level_;
   boost::optional<double> target_acceleration_;
   boost::optional<double> target_steering_angle_;
+  /// Vehicle state determined by a vehicle dynamics model.
+  /// Object pose, velocity, acceleration, angular_velocity in world coordinates.
   boost::optional<Object> vehicle_state_;
   std::function<void(void)> vehicle_state_callback_;
 };

--- a/models/include/cloe/component/utility/ego_sensor_canon.hpp
+++ b/models/include/cloe/component/utility/ego_sensor_canon.hpp
@@ -50,6 +50,12 @@ class EgoSensorCanon : public EgoSensor {
   explicit EgoSensorCanon(std::shared_ptr<const EgoSensor> ego) : ego_(ego) {}
   const Object& sensed_state() const override { return ego_->sensed_state(); }
   double wheel_steering_angle() const override { return ego_->wheel_steering_angle(); }
+  double driver_request_acceleration() const override {
+    return ego_->driver_request_acceleration();
+  }
+  double driver_request_wheel_steering_angle() const override {
+    return ego_->driver_request_wheel_steering_angle();
+  }
   double steering_wheel_speed() const override { return ego_->steering_wheel_speed(); }
   double vehicle_length() const { return sensed_state().dimensions.x(); }
   double vehicle_width() const { return sensed_state().dimensions.y(); }

--- a/models/include/cloe/utility/geometry.hpp
+++ b/models/include/cloe/utility/geometry.hpp
@@ -52,11 +52,31 @@ inline Eigen::Isometry3d pose_from_rotation_translation(const Eigen::Quaterniond
 }
 
 /**
- * Change a point's frame of reference.
- * Both the point and the child frame need to have the same parent frame.
+ * Compute the roll, pitch and yaw angles from a given pose.
+ *  - \param pose: Pose of which the rotation matrix shall be expressed in Euler angles.
  */
-inline void transform_to_child_frame(const Eigen::Isometry3d& child_frame, Eigen::Vector3d* point) {
-  *point = child_frame.inverse() * (*point);
+inline Eigen::Vector3d get_pose_roll_pitch_yaw(const Eigen::Isometry3d& pose) {
+  return pose.rotation().matrix().eulerAngles(2, 1, 0).reverse();
+}
+
+/**
+ * Change a point's frame of reference from the parent frame to the child frame.
+ *  - \param child_frame: Pose of the child reference frame w.r.t. the parent frame.
+ *  - \param pt_vec: Point coordinate vector w.r.t. the parent frame.
+ */
+inline void transform_point_to_child_frame(const Eigen::Isometry3d& child_frame,
+                                           Eigen::Vector3d* pt_vec) {
+  *pt_vec = child_frame.inverse() * (*pt_vec);
+}
+
+/**
+ * Change a point's frame of reference from the child frame to the parent frame.
+ *  - \param child_frame: Pose of the child reference frame w.r.t. the parent frame.
+ *  - \param pt_vec_child: Point coordinate vector w.r.t. the child frame.
+ */
+inline void transform_point_to_parent_frame(const Eigen::Isometry3d& child_frame,
+                                            Eigen::Vector3d* pt_vec_child) {
+  *pt_vec_child = child_frame * (*pt_vec_child);
 }
 
 }  // namespace utility

--- a/plugins/vtd/CMakeLists.txt
+++ b/plugins/vtd/CMakeLists.txt
@@ -55,6 +55,7 @@ if(BuildTests)
         src/rdb_transceiver_tcp_test.cpp
         src/osi_test.cpp
         src/vtd_osi_test.cpp
+        src/vtd_data_conversion_test.cpp
     )
     set_target_properties(test-vtd-binding PROPERTIES
         CXX_STANDARD 14

--- a/plugins/vtd/src/osi_omni_sensor.cpp
+++ b/plugins/vtd/src/osi_omni_sensor.cpp
@@ -627,8 +627,8 @@ void OsiOmniSensor::from_osi_boundary_points(const osi3::LaneBoundary& osi_lb,
     const auto& osi_pt = osi_lb.boundary_line(i);
     Eigen::Vector3d position = osi_vector3d_xyz_to_vector3d(osi_pt.position());
     // Transform points from the inertial into the sensor reference frame.
-    cloe::utility::transform_to_child_frame(osi_ego_pose_, &position);
-    cloe::utility::transform_to_child_frame(osi_sensor_pose_, &position);
+    cloe::utility::transform_point_to_child_frame(osi_ego_pose_, &position);
+    cloe::utility::transform_point_to_child_frame(osi_sensor_pose_, &position);
     lb.points.push_back(position);
   }
   // Compute clothoid segment. TODO(tobias): implement curved segments.

--- a/plugins/vtd/src/osi_utils.cpp
+++ b/plugins/vtd/src/osi_utils.cpp
@@ -115,7 +115,7 @@ void osi_transform_base_moving(const osi3::BaseMoving& base_ref, osi3::BaseMovin
 
   // Transform base.position/orientation/velocity/acceleration/orientation_rate:
   Eigen::Vector3d pos_ref_frame = pose.translation();
-  cloe::utility::transform_to_child_frame(pose_ref, &pos_ref_frame);
+  cloe::utility::transform_point_to_child_frame(pose_ref, &pos_ref_frame);
   pose.translation() = pos_ref_frame;          // location in reference frame
   pose.rotate(pose_ref.rotation().inverse());  // orientation in reference frame
   // Write new pose to base.

--- a/plugins/vtd/src/vtd_binding.cpp
+++ b/plugins/vtd/src/vtd_binding.cpp
@@ -385,11 +385,6 @@ class VtdBinding : public cloe::Simulator {
     // b) to catch any restart requests.
     this->readall_scp();
 
-    // Send items to TaskControl:
-    for (auto v : vehicles_) {
-      v->vtd_step_actuator(*scp_client_, config_.label_vehicle);
-    }
-
     // Process task control messages
     {
       timer::DurationTimer<timer::Milliseconds> t([this](timer::Milliseconds d) {
@@ -407,6 +402,11 @@ class VtdBinding : public cloe::Simulator {
       for (auto v : vehicles_) {
         sensor_time = v->vtd_step_sensors(sync);
       }
+    }
+
+    // Send items to TaskControl:
+    for (auto v : vehicles_) {
+      v->vtd_step_actuator(*scp_client_, config_.label_vehicle);
     }
 
     // Trigger VTD to simulation the next step

--- a/plugins/vtd/src/vtd_data_conversion_test.cpp
+++ b/plugins/vtd/src/vtd_data_conversion_test.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Robert Bosch GmbH
+
+ */
+/**
+ * \file vtd_data_conversion_test.cpp
+ * \see  omni_sensor_component.hpp
+ * \see  task_control.hpp
+ */
+
+#include <cmath>  // for M_PI
+
+#include <gtest/gtest.h>              // for TEST, ASSERT_TRUE
+#include <cloe/component/object.hpp>  // for Object
+
+#include "omni_sensor_component.hpp"
+#include "task_control.hpp"
+
+RDB_COORD_t get_test_rdb_coord() {
+  RDB_COORD_t c;
+  c.x = 1.0;
+  c.y = 2.0;
+  c.z = 3.0;
+  c.h = 0.1 * M_PI;
+  c.p = 0.2 * M_PI;
+  c.r = 0.3 * M_PI;
+  c.flags = RDB_COORD_FLAG_POINT_VALID | RDB_COORD_FLAG_ANGLES_VALID;
+  return c;
+}
+
+void assert_rdb_coord_eq(const RDB_COORD_t& c1, const RDB_COORD_t& c2) {
+  ASSERT_DOUBLE_EQ(c1.x, c2.x);
+  ASSERT_DOUBLE_EQ(c1.y, c2.y);
+  ASSERT_DOUBLE_EQ(c1.z, c2.z);
+  if (c2.flags & RDB_COORD_FLAG_ANGLES_VALID) {
+    ASSERT_DOUBLE_EQ(c1.h, c2.h);
+    ASSERT_DOUBLE_EQ(c1.p, c2.p);
+    ASSERT_DOUBLE_EQ(c1.r, c2.r);
+  }
+}
+
+TEST(vtd_data, rdb_coord) {
+  // Convert from VTD to Cloe data and back.
+  RDB_COORD_t coord = get_test_rdb_coord();
+  cloe::Object obj;
+  obj.pose = vtd::from_vtd_pose(coord);
+  RDB_COORD_t coord2 = vtd::rdb_coord_from_object(obj);
+  assert_rdb_coord_eq(coord, coord2);
+  coord2 = vtd::rdb_coord_pos_from_vector3d(obj.pose.translation());
+  assert_rdb_coord_eq(coord, coord2);
+}

--- a/plugins/vtd/src/vtd_sensor_components.hpp
+++ b/plugins/vtd/src/vtd_sensor_components.hpp
@@ -37,6 +37,12 @@ class VtdEgoSensor : public cloe::EgoSensor {
 
   const cloe::Object& sensed_state() const override { return data_->get_ego_object(); }
   double wheel_steering_angle() const override { return data_->get_ego_steering_angle(); }
+  double driver_request_acceleration() const override {
+    return task_control_->get_driver_request_acceleration(id_);
+  }
+  double driver_request_wheel_steering_angle() const override {
+    return task_control_->get_driver_request_steering_angle(id_);
+  }
   virtual double steering_wheel_speed() const override {
     return task_control_->get_steering_wheel_speed(id_);
   }

--- a/plugins/vtd/src/vtd_vehicle.hpp
+++ b/plugins/vtd/src/vtd_vehicle.hpp
@@ -92,7 +92,7 @@ class VtdVehicle : public cloe::Vehicle {
     auto sensor = std::make_shared<VtdOmniSensor>(std::move(rdb_client), id);
     sensors_[DEFAULT_SENSOR_NAME] = sensor;
     sensor->set_name(name + "_omni_sensor");
-    actuator_ = std::make_shared<VtdLatLongActuator>(task_control, id);
+    actuator_ = std::make_shared<VtdLatLongActuator>(task_control, id, vtd_name_);
 
     // Add ego sensor
     this->new_component(new VtdEgoSensor{id, sensor, task_control},
@@ -145,7 +145,7 @@ class VtdVehicle : public cloe::Vehicle {
    */
   void vtd_step_actuator(ScpTransceiver& tx, LabelConfiguration lbl) {
     // Send actuations
-    this->actuator_->add_driver_control();
+    this->actuator_->add_actuation();
     if (lbl != LabelConfiguration::Off) {
       this->update_label(tx, lbl);
     }
@@ -332,7 +332,9 @@ class VtdVehicleFactory {
             veh->sensors_[name] = osi;
             break;
           }
-          default: { throw cloe::Error("VtdVehicle: unknown sensor protocol"); }
+          default: {
+            throw cloe::Error("VtdVehicle: unknown sensor protocol");
+          }
         }
       }
       veh->configure_components(vcfg.components);


### PR DESCRIPTION
Cloe shall support the computation of the ego vehicle state by a 3rd-party model. For that, the new vehicle state must be provided to the environment simulator and the model data i/o must be consistent (timestamp of ego data, controller requests, vehicle state w.r.t. environment state).  Here, `LatLongActuator` was extended and the VTD simulator binding was modified to support the following procedure in every step:
* first obtain the environment and ego state at t(i)
* step a 3rd-party actuator model from t(i) to t(i+1), using ego state and driver/control requests at t(i)
* send the vehicle state at t(i+1) to the simulator
* trigger the simulator to step the environment to t(i+1)