### PR TITLE
Add detailed performance timings

### DIFF
--- a/Makefile.setup
+++ b/Makefile.setup
@@ -98,6 +98,7 @@ install-ubuntu-deps::
 		curl \
 		file \
 		git \
+		gnuplot \
 		graphviz \
 		jq \
 		patchelf \
@@ -125,6 +126,7 @@ install-archlinux-deps::
 		curl \
 		doxygen \
 		git \
+		gnuplot \
 		graphviz \
 		jq \
 		patchelf \

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(${target}
     src/plugins/nop_simulator.cpp
     src/simulation.cpp
     src/simulation_context.cpp
+    src/simulation_performance.cpp
     src/utility/command.cpp
 )
 set_target_properties(${target} PROPERTIES

--- a/engine/src/simulation.hpp
+++ b/engine/src/simulation.hpp
@@ -42,6 +42,7 @@ struct SimulationResult {
   cloe::Duration elapsed;
   SimulationOutcome outcome;
   SimulationStatistics statistics;
+  SimulationPerformance performance;
   cloe::Json triggers;
   boost::optional<boost::filesystem::path> output_dir;
 
@@ -123,12 +124,37 @@ class Simulation {
   size_t write_output(const SimulationResult&) const;
 
   /**
+   * Write the plugin performance files, and generate plots if requested and
+   * gnuplot available.
+   *
+   * Return number of files written.
+   */
+  size_t write_performance_files(const boost::filesystem::path& dir, const SimulationPerformance& r) const;
+
+  /**
    * Write the given JSON output into the file. Return true if successful.
    */
   bool write_output_file(const boost::filesystem::path& filepath, const cloe::Json& j) const;
 
   /**
-   * Check if the given filepath may be opened, respecting clobber options.
+   * Lazily write to the output file if it can be opened for writing.
+   *
+   * This is better than accepting a string, because generation can be delayed
+   * until we are sure we can use it. This uses `is_writable()` to determine
+   * if the file in question can be written to.
+   *
+   * Return whether the operation was successful or not. This may not
+   * necessarily stem from an error; if it does, an error message will be
+   * logged.
+   */
+  bool write_output_file(const boost::filesystem::path& filepath,
+                         std::function<void(std::ostream& os)> func) const;
+
+  /**
+   * Return whether the given filepath may be opened for writing, respecting
+   * clobber options.
+   *
+   * The clobber option is set in the engine configuration section.
    */
   bool is_writable(const boost::filesystem::path& filepath) const;
 

--- a/engine/src/simulation_context.cpp
+++ b/engine/src/simulation_context.cpp
@@ -69,6 +69,17 @@ std::shared_ptr<cloe::Registrar> SimulationContext::simulation_registrar() {
   }
 }
 
+cloe::Duration SimulationContext::process_model(cloe::Model& m) {
+  timer::DurationTimer<cloe::Duration> t([this, &m](cloe::Duration d) {
+    auto ms = std::chrono::duration_cast<cloe::Milliseconds>(d);
+    this->statistics.plugin_time_ms[m.name()].push_back(ms.count());
+    if (this->config.engine.performance_profile_plugins) {
+      this->performance.push_back(m.name(), ms.count());
+    }
+  });
+  return m.process(this->sync);
+}
+
 bool SimulationContext::foreach_model(std::function<bool(cloe::Model&, const char*)> f) {
   for (auto& kv : controllers) {
     auto ok = f(*kv.second, "controller");

--- a/engine/src/simulation_performance.cpp
+++ b/engine/src/simulation_performance.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file simulation_performance.cpp
+ * \see  simulation_performance.hpp
+ */
+
+#include "simulation_performance.hpp"
+
+#include <iostream> // for endl
+
+#include <fmt/format.h> // for join
+
+namespace engine {
+
+void TimingSamples::swap(TimingSamples& other) {
+  using std::swap;
+  swap(step, other.step);
+  swap(samples, other.samples);
+}
+
+void TimingSamples::push_back(std::string&& name, double ms) {
+  samples.push_back(std::make_pair(name, ms));
+}
+
+double TimingSamples::total(const std::string& key) const {
+  double sum = 0.0;
+  for (const auto& pair : samples) {
+    if (pair.first == key) {
+      sum += pair.second;
+    }
+  }
+  return sum;
+}
+
+double TimingSamples::total() const {
+  double sum = 0.0;
+  for (const auto& pair : samples) {
+    sum += pair.second;
+  }
+  return sum;
+}
+
+std::vector<std::string> TimingSamples::keys() const {
+  std::vector<std::string> results;
+  if (samples.empty()) {
+    return results;
+  }
+
+  // Remove duplicate keys (these follow directly after one-another), by
+  // appending the buffer when we see a new key. We add the final key at the
+  // end then.
+  std::string buffer = samples[0].first;
+  for (const auto& pair : samples) {
+    if (buffer != pair.first) {
+      results.push_back(buffer);
+      buffer = pair.first;
+    }
+  }
+  results.push_back(buffer);
+  return results;
+}
+
+std::vector<double> TimingSamples::values() const {
+  std::vector<double> results;
+  if (samples.empty()) {
+    return results;
+  }
+
+  // Sum groups of samples belonging to the same entity.
+  std::string buffer = samples[0].first;
+  double sum = 0.0;
+  for (const auto& pair : samples) {
+    if (buffer != pair.first) {
+      results.push_back(sum);
+      buffer = pair.first;
+      sum = 0.0;
+    }
+    sum += pair.second;
+  }
+  results.push_back(sum);
+  return results;
+}
+
+void to_json(cloe::Json& j, const TimingSamples& s) {
+  j = cloe::Json{
+      {"step", s.step},
+      {"samples", s.samples},
+  };
+}
+
+std::vector<std::pair<uint64_t, double>> SimulationPerformance::values_for(const std::string& key) const {
+  std::vector<std::pair<uint64_t, double>> results;
+  for (const auto& p : steps) {
+    results.emplace_back(std::make_pair(p.step, p.total(key)));
+  }
+  return results;
+}
+
+std::vector<std::pair<uint64_t, std::vector<double>>> SimulationPerformance::values() const {
+  std::vector<std::pair<uint64_t, std::vector<double>>> results;
+  for (const auto& p : steps) {
+    results.emplace_back(std::make_pair(p.step, p.values()));
+  }
+  return results;
+}
+
+void to_json(cloe::Json& j, const SimulationPerformance& s) { j = s.steps; }
+
+void write_csv(std::ostream& os, const SimulationPerformance& s) {
+  os << fmt::format("step,{}\n", fmt::join(s.keys(), ","));
+  for (const auto& x : s.steps) {
+    os << fmt::format("{},{}\n", x.step, fmt::join(x.values(), ","));
+  }
+}
+
+void write_gnuplot(std::ostream& os, const SimulationPerformance& s) {
+  os << fmt::format("{}\n", fmt::join(s.keys(), ","));
+  for (const auto& x : s.steps) {
+    os << fmt::format("{},{}\n", x.step, fmt::join(x.values(), ","));
+  }
+}
+
+}  // namespace engine

--- a/engine/src/simulation_performance.hpp
+++ b/engine/src/simulation_performance.hpp
@@ -104,7 +104,7 @@ struct SimulationPerformance {
  public:
   void init_step(uint64_t step) {
     buffer.step = step;
-    assert(buffer.samples.is_empty());
+    assert(buffer.samples.empty());
   }
 
   void commit_step(double padding, double cycle) {

--- a/engine/src/simulation_performance.hpp
+++ b/engine/src/simulation_performance.hpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file simulation_performance.hpp
+ * \see  simulation_performance.cpp
+ */
+
+#pragma once
+
+#include <cstdint>  // for uint64_t
+#include <string>   // for string
+#include <utility>  // for pair<>, make_pair
+#include <vector>   // for vector<>
+#include <ostream> // for ostream
+
+#include <cloe/core.hpp>  // for Duration, Json
+
+namespace engine {
+
+/**
+ * Store the timing samples for multiple entities for a single step.
+ *
+ * This represents a line in a CSV file, for example, with each additional
+ * column after the first being the entity, in order. For example:
+ *
+ *    step  minimator  basic  virtue  (cloe_padding)  (cloe_engine)
+ *    1     0.3        0.5    1.2     0.0             3.4
+ *    2     0.2        0.3    1.1     0.0             3.2
+ *    ...
+ */
+struct TimingSamples {
+  uint64_t step;
+  std::vector<std::pair<std::string, double>> samples;
+
+ public:
+  TimingSamples() = default;
+  TimingSamples(uint64_t step) : step(step) {}
+
+  // This implements the suggestion from Scott Meyer's Effective C++ 3rd
+  // Edition, Item 25. See also template specialization at bottom of file.
+  void swap(TimingSamples& other);
+
+  /**
+   * Push back the duration used by the entity.
+   *
+   * Note that it is valid to re-use the same entity name, iff it follows
+   * directly upon itself. (That is: [a, a, b, c, c] is valid, but [a, b, a, c]
+   * is not valid.)
+   */
+  void push_back(std::string&& name, double duration);
+
+  /**
+   * Return the total duration the entity used.
+   *
+   * This method doesn't care about how the entries are ordered.
+   * This will return 0 if the entity does not exist.
+   */
+  double total(const std::string& key) const;
+
+  /**
+   * Return the total duration used so far by all entities.
+   */
+  double total() const;
+
+  /**
+   * Return an array of plugin and cloe timing keys.
+   *
+   * The order reflects the order that the plugins are called.
+   */
+  std::vector<std::string> keys() const;
+
+  /**
+   * Return an array of plugin and cloe timings.
+   *
+   * This should have the same length as `keys()` and groups values
+   * accordingly.
+   */
+  std::vector<double> values() const;
+
+  friend void to_json(cloe::Json& j, const TimingSamples& s);
+};
+
+struct SimulationPerformance {
+  std::vector<TimingSamples> steps;
+
+ private:
+  TimingSamples buffer;
+
+ public:
+  void init_step(uint64_t step) {
+    buffer.step = step;
+    assert(buffer.samples.is_empty());
+  }
+
+  void commit_step(double padding, double cycle) {
+    // Names can't contain parenthesis, so we wrap these non-plugin times in
+    // parenthesis to disambiguate any plugins that might be named the same.
+    push_back("(cloe_padding)", padding);
+    push_back("(cloe_engine)", cycle - buffer.total());
+
+    TimingSamples tmp;
+    tmp.swap(buffer);
+    steps.emplace_back(std::move(tmp));
+  }
+
+  void push_back(std::string&& name, double ms) { buffer.push_back(std::move(name), ms); }
+
+  void reset() { steps.clear(); }
+
+  bool is_empty() const { return steps.empty(); }
+
+  /**
+   * Return an array of (step, duration) for the given entity.
+   */
+  std::vector<std::pair<uint64_t, double>> values_for(const std::string& key) const;
+
+  /**
+   * Return an array of (step, [duration1, duration2, ...]) for all entities.
+   *
+   * This can be combined with `keys()` for 1-to-1 mapping, which is useful for
+   * tabular output.
+   */
+  std::vector<std::pair<uint64_t, std::vector<double>>> values() const;
+
+  std::vector<std::string> keys() const {
+    assert(!steps.empty());
+    return steps[0].keys();
+  }
+
+  friend void write_gnuplot(std::ostream& os, const SimulationPerformance& s);
+  friend void write_csv(std::ostream& os, const SimulationPerformance& s);
+  friend void to_json(cloe::Json& j, const SimulationPerformance& s);
+};
+
+}  // namespace engine
+
+namespace std {
+
+// This implements the suggestion from Scott Meyer's Effective C++ 3rd
+// Edition, Item 25.
+template <>
+inline void swap<::engine::TimingSamples>(::engine::TimingSamples& a,
+                                          ::engine::TimingSamples& b) noexcept {
+  a.swap(b);
+}
+
+}  // namespace std

--- a/engine/src/stack.hpp
+++ b/engine/src/stack.hpp
@@ -326,7 +326,15 @@ struct EngineConf : public Confable {
   boost::optional<boost::filesystem::path> output_file_result{"result.json"};
   boost::optional<boost::filesystem::path> output_file_triggers{"triggers.json"};
   boost::optional<boost::filesystem::path> output_file_data_stream;
+  boost::optional<boost::filesystem::path> output_dir_performance{"performance"};
   bool output_clobber_files{true};
+
+  // Performance:
+  bool performance_profile_plugins{false};
+  bool performance_generate_plots{true};
+
+  // Executables:
+  boost::filesystem::path executable_gnuplot{"gnuplot"};
 
   /**
    * Number of milliseconds between states when waiting for continuation.
@@ -429,6 +437,16 @@ struct EngineConf : public Confable {
               {"triggers", make_schema(&output_file_triggers, file_proto(), "file to store triggers in")},
               {"api_recording", make_schema(&output_file_data_stream, file_proto(), "file to store api data stream")},
            }},
+           {"dirs", Struct{
+              {"performance", make_schema(&output_dir_performance, dir_proto(), "directory to store plugin performance in")},
+           }},
+        }},
+        {"performance", Struct{
+          {"profile_plugins", make_schema(&performance_profile_plugins, "whether to profile plugin performance and write output files; see config /engine/output/dirs/performance")},
+          {"generate_plots", make_schema(&performance_generate_plots, "whether to use gnuplot to generate plots; see config /engine/executables/gnuplot")},
+        }},
+        {"executables", Struct{
+          {"gnuplot", make_schema(&executable_gnuplot, "path to gnuplot executable")},
         }},
         {"triggers", Struct{
            {"ignore_source", make_schema(&triggers_ignore_source, "ignore trigger source when reading in triggers")},

--- a/engine/src/stack_test.cpp
+++ b/engine/src/stack_test.cpp
@@ -43,6 +43,9 @@ TEST(cloe_stack, serialization_of_empty_stack) {
   Json expect = R"({
     "engine": {
       "keep_alive": false,
+      "executables": {
+        "gnuplot": "gnuplot"
+      },
       "hooks": {
         "post_disconnect": [],
         "pre_connect": []
@@ -51,6 +54,9 @@ TEST(cloe_stack, serialization_of_empty_stack) {
       "output": {
         "clobber": true,
         "path": "${CLOE_SIMULATION_UUID}",
+        "dirs": {
+          "performance": "performance"
+        },
         "files": {
           "config": "config.json",
           "result": "result.json",
@@ -58,6 +64,10 @@ TEST(cloe_stack, serialization_of_empty_stack) {
         }
       },
       "registry_path": "${XDG_DATA_HOME-${HOME}/.local/share}/cloe/registry",
+      "performance": {
+        "generate_plots": true,
+        "profile_plugins": false
+      },
       "plugin_path": [],
       "plugins": {
         "allow_clobber": true,
@@ -134,6 +144,9 @@ TEST(cloe_stack, serialization_with_logging) {
   Json expect = R"({
     "engine": {
       "keep_alive": false,
+      "executables": {
+        "gnuplot": "gnuplot"
+      },
       "hooks": {
         "post_disconnect": [],
         "pre_connect": []
@@ -142,11 +155,18 @@ TEST(cloe_stack, serialization_with_logging) {
       "output": {
         "clobber": true,
         "path": "${CLOE_SIMULATION_UUID}",
+        "dirs": {
+          "performance": "performance"
+        },
         "files": {
           "config": "config.json",
           "result": "result.json",
           "triggers": "triggers.json"
         }
+      },
+      "performance": {
+        "generate_plots": true,
+        "profile_plugins": false
       },
       "registry_path": "${XDG_DATA_HOME-${HOME}/.local/share}/cloe/registry",
       "plugin_path": [],

--- a/tests/option_performance_measurements.json
+++ b/tests/option_performance_measurements.json
@@ -1,0 +1,9 @@
+{
+  "version": "4",
+  "engine": {
+    "performance": {
+      "profile_plugins": true,
+      "generate_plots": true
+    }
+  }
+}


### PR DESCRIPTION
This change is required for analyzing plugin performance.

Work left:

- [ ] Fix schema system tests
- [ ] Add script to generate gnuplot from `performance.json`
  - [ ] Export `performance.csv` or `performance.jq`
  - [ ] Export `performance.gnuplot`
- [ ] Document this capability