### PR TITLE
tooling: Add build environment docker images

### DIFF
--- a/dist/docker/Dockerfile.bionic
+++ b/dist/docker/Dockerfile.bionic
@@ -6,7 +6,7 @@ ARG VTD_IMAGE=scratch
 FROM ${VTD_IMAGE} AS vtd
 WORKDIR /vtd
 
-FROM ubuntu:18.04
+FROM ubuntu:18.04 as cloe-base
 
 # Install System Packages
 COPY Makefile.setup /cloe/Makefile.setup
@@ -42,6 +42,7 @@ RUN conan profile new --detect default && \
 ENV CONAN_NON_INTERACTIVE=yes
 
 # Build and Install Cloe
+FROM cloe-base as cloe-build
 WORKDIR /cloe
 ARG WITH_VTD=0
 ARG KEEP_SOURCES=0

--- a/dist/docker/Dockerfile.focal
+++ b/dist/docker/Dockerfile.focal
@@ -13,7 +13,7 @@ ARG VTD_IMAGE=scratch
 FROM ${VTD_IMAGE} AS vtd
 WORKDIR /vtd
 
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as cloe-base
 
 # Install System Packages
 #
@@ -59,6 +59,7 @@ ENV CONAN_NON_INTERACTIVE=yes
 # All common processes are made easy to apply by writing target recipes in the
 # Makefile at the root of the repository. This also acts as a form of
 # documentation.
+FROM cloe-base as cloe-build
 WORKDIR /cloe
 ARG WITH_VTD=0
 ARG KEEP_SOURCES=0

--- a/dist/docker/Dockerfile.xenial
+++ b/dist/docker/Dockerfile.xenial
@@ -6,7 +6,7 @@ ARG VTD_IMAGE=scratch
 FROM ${VTD_IMAGE} AS vtd
 WORKDIR /vtd
 
-FROM ubuntu:16.04
+FROM ubuntu:16.04 as cloe-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -94,6 +94,7 @@ RUN conan profile new --detect default && \
 ENV CONAN_NON_INTERACTIVE=yes
 
 # Build and Install Cloe
+FROM cloe-base as cloe-build
 WORKDIR /cloe
 ARG WITH_VTD=0
 ARG KEEP_SOURCES=0

--- a/dist/docker/Makefile
+++ b/dist/docker/Makefile
@@ -16,10 +16,12 @@ DOCKER_NETWORK := \
 		fi \
 	)
 
-IMAGE_BASE := cloe/cloe-engine
+IMAGE_BASE := cloe
 IMAGE_VERSION := ${PROJECT_VERSION}
-DOCKER_IMAGE := ${IMAGE_BASE}:${IMAGE_VERSION}
+DOCKER_IMAGE := ${IMAGE_BASE}/cloe-engine:${IMAGE_VERSION}
+DOCKER_IMAGE_BUILD_ENV := ${IMAGE_BASE}/build-env:${IMAGE_VERSION}
 DOCKER_CONTEXT := ${PROJECT_ROOT}
+BUILD_ENV_DIST := ubuntu-20.04
 
 # Default build arguments
 VENDOR_TARGET :=
@@ -107,6 +109,23 @@ ubuntu-20.04: Dockerfile.focal
 archlinux: Dockerfile.archlinux
 	@echo ===================================================================================
 	${DOCKER} build -f $< ${DOCKER_ARGS} -t ${DOCKER_IMAGE}-$@ ${DOCKER_CONTEXT}
+
+.PHONY: build-env
+build-env: ${BUILD_ENV_DIST}-build-env
+
+.PHONY: info-build-env
+info-build-env:
+	@echo ${DOCKER_IMAGE_BUILD_ENV}-${BUILD_ENV_DIST}
+
+.PHONY: ubuntu-18.04-build-env
+ubuntu-18.04-build-env: Dockerfile.bionic
+	@echo ===================================================================================
+	${DOCKER} build --target cloe-base -f $< ${DOCKER_ARGS} -t ${DOCKER_IMAGE_BUILD_ENV}-ubuntu-18.04 ${DOCKER_CONTEXT}
+
+.PHONY: ubuntu-20.04-build-env
+ubuntu-20.04-build-env: Dockerfile.focal
+	@echo ===================================================================================
+	${DOCKER} build --target cloe-base -f $< ${DOCKER_ARGS} -t ${DOCKER_IMAGE_BUILD_ENV}-ubuntu-20.04 ${DOCKER_CONTEXT}
 
 release:
 	@test -f setup.sh || echo 'Error: require setup.sh for user authentication'


### PR DESCRIPTION
The objective is to have additional docker build targets for base images that can be useful, e.g. to build dev-containers.