### PR TITLE
Alternative lockfile implementation

### DIFF
--- a/Makefile.all
+++ b/Makefile.all
@@ -9,6 +9,10 @@ SHELL := /bin/bash
 GNUMAKEFLAGS := --no-print-directory
 SUBMAKEFLAGS :=
 
+define assert_numeric_bool
+$(if $(filter-out 0 1,${$1}), $(error Unexpected value for parameter $1, expect either 0 or 1))
+endef
+
 ## USE_NPROC
 ##   Usage: make USE_NPROC=1 <targets>
 ##   Default: 0
@@ -22,6 +26,8 @@ SUBMAKEFLAGS :=
 ##       make USE_NPROC=1 NPROC=3 <targets>
 ##
 USE_NPROC := 0
+$(call assert_numeric_bool, USE_NPROC)
+
 ifeq (${USE_NPROC},1)
 NPROC := $(shell nproc 2>/dev/null)
 ifdef NPROC
@@ -79,12 +85,14 @@ CONAN_OPTIONS :=
 ##   Default: 1
 ##
 WITH_ENGINE := 1
+$(call assert_numeric_bool, WITH_ENGINE)
 
 ## WITH_VTD
 ##   Usage: make WITH_VTD=1 <targets>
 ##   Default: 0
 ##
 WITH_VTD := 0
+$(call assert_numeric_bool, WITH_VTD)
 
 ## BUILD_TESTS
 ##   Usage: make BUILD_TESTS=0 package
@@ -95,6 +103,7 @@ WITH_VTD := 0
 ##   to showcase how to correctly pass options to all packages.
 ##
 BUILD_TESTS := 1
+$(call assert_numeric_bool, WITH_TESTS)
 
 # --------------------------------------------------------------------------- #
 

--- a/Makefile.package
+++ b/Makefile.package
@@ -36,19 +36,15 @@ endif
 SOURCE_DIR       := .
 SOURCE_CONANFILE := conanfile.py
 SOURCE_CMAKELISTS:= ${SOURCE_DIR}/CMakeLists.txt
+LOCKFILE_SOURCE  :=
+LOCKFILE_OPTION  :=
 CLEAN_SOURCE_DIR := false
 BUILD_DIR        := build
 BUILD_CONANINFO  := ${BUILD_DIR}/conanbuildinfo.cmake
 BUILD_CMAKECACHE := ${BUILD_DIR}/CMakeCache.txt
+BUILD_LOCKFILE   := ${BUILD_DIR}/conan.lock
 BUILD_LAYOUT     := ${PROJECT_ROOT}/.conan-layout.ini
 BUILD_POLICY     := missing
-
-# Normally, you should set this in your profile, but if you just want to build
-# the package in debug mode once, you can do it this way, although it will
-# only apply to local builds.
-#
-# This can be one of: None, Debug, Release, RelWithDebInfo, MinSizeRel
-BUILD_TYPE := RelWithDebInfo
 
 PACKAGE_NAME    := $(shell sed -rn 's/.*name\s*=\s*"([^"]+)"$$/\1/p' ${SOURCE_CONANFILE})
 PACKAGE_VERSION := $(or \
@@ -59,22 +55,42 @@ PACKAGE_VERSION := $(or \
 PACKAGE_CHANNEL := cloe/develop
 PACKAGE_FQN     := ${PACKAGE_NAME}/${PACKAGE_VERSION}@${PACKAGE_CHANNEL}
 
-# Determining the PACKAGE_DIR takes a long time because we have to call Conan,
-# so only do it for the targets that actually make use of it.
-ifneq "$(filter help list status,${MAKECMDGOALS})" ""
-PACKAGE_INFO := $(shell conan info ${PACKAGE_FQN} --package-filter ${PACKAGE_FQN} --paths 2>/dev/null | sed -r 's/$$/\\n/')
-PACKAGE_ID := $(shell echo "${PACKAGE_INFO}" | sed -rn "s/^ *ID: *(.*)$$/\1/p")
-PACKAGE_DIR := $(shell echo "${PACKAGE_INFO}" | sed -rn "s/^ *package_folder: *(.*)$$/\1/p")
-PACKAGE_DATE := $(shell echo "${PACKAGE_INFO}" | sed -rn "s/^ *Creation date: *(.*)$$/\1/p")
-endif
+# Normally, you should set this in your profile, but if you just want to build
+# the package in debug mode once, you can do it this way, although it will
+# only apply to local builds.
+#
+# This can be one of: None, Debug, Release, RelWithDebInfo, MinSizeRel
+BUILD_TYPE := RelWithDebInfo
+BUILD_TYPE_OPTION := -s ${PACKAGE_NAME}:build_type=${BUILD_TYPE}
 
 # These options can be set to influence package and configure.
 CONAN_OPTIONS :=
 
+.PHONY: ${BUILD_LOCKFILE}
+ifneq "${LOCKFILE_SOURCE}" ""
+ifeq "$(realpath ${LOCKFILE_SOURCE})" "$(realpath ${SOURCE_CONANFILE})"
+$(error "LOCKFILE_SOURCE must contain superset of SOURCE_CONANFILE package and dependencies")
+endif
+LOCKFILE_OPTION := --lockfile="${BUILD_LOCKFILE}"
+${BUILD_LOCKFILE}: ${LOCKFILE_SOURCE} | ${BUILD_DIR} export
+	# Create lockfile from LOCKFILE_SOURCE.
+	#
+	conan lock create --lockfile-out "${BUILD_LOCKFILE}" ${BUILD_TYPE_OPTION} ${CONAN_OPTIONS} --build -- "${LOCKFILE_SOURCE}" >/dev/null
+endif
+
+# When using a --lockfile option, we cannot use profile, settings, options, env
+# or conf 'host' Conan options.
+ifneq "${LOCKFILE_OPTION}" ""
+ALL_OPTIONS := ${LOCKFILE_OPTION} ${CONAN_OPTIONS}
+else
+ALL_OPTIONS := ${BUILD_TYPE_OPTION} ${CONAN_OPTIONS}
+endif
+
+# INFORMATIONAL TARGETS -------------------------------------------------------
 .DEFAULT: help
-.SILENT: help status info-name info-version info-channel info-fqn
-.PHONY: help status info-name info-version info-channel info-fqn
-help::
+.SILENT: help status parse-info info-name info-version info-channel info-fqn info
+.PHONY: help status parse-info info-name info-version info-channel info-fqn info
+help:: parse-info
 	echo "Usage: make <target>"
 	echo
 	echo "The following targets define common operations with this package in"
@@ -83,6 +99,7 @@ help::
 	echo "Available targets:"
 	echo "  help        to show this help"
 	echo "  status      to show status of package"
+	echo "  info        to show detailed package info"
 	echo
 	echo "  export            to export recipe and sources        [conan-cache]"
 	echo "  download          to download or create package       [conan-cache]"
@@ -103,6 +120,7 @@ help::
 	echo "  clean       to remove build directory                   [in-source]"
 	echo
 	echo "Configuration:"
+	echo "  LOCKFILE_SOURCE: ${LOCKFILE_SOURCE}"
 	echo "  SOURCE_DIR:      ${SOURCE_DIR}"
 	echo "  BUILD_DIR:       ${BUILD_DIR}"
 	echo "  BUILD_POLICY:    ${BUILD_POLICY}"
@@ -120,7 +138,19 @@ help::
 	echo "  GIT_COMMIT_HASH: ${GIT_COMMIT_HASH}"
 	echo
 
-status:
+parse-info: ${BUILD_LOCKFILE}
+	# Fetch package information from Conan.
+	#
+	#   This command takes long, so we won't run it by default. Instead, if any
+	#   target needs one of these variables, they should depend on this target
+	#   to ensure that these variables are set.
+	#
+	$(eval PACKAGE_INFO := $(shell conan info ${ALL_OPTIONS} "${PACKAGE_FQN}" --package-filter "${PACKAGE_FQN}" --paths | sed -r 's/$$/\\n/'))
+	$(eval PACKAGE_ID := $(shell echo -e "${PACKAGE_INFO}" | sed -rn 's/^ *ID: *(.*)$$/\1/p'))
+	$(eval PACKAGE_DIR := $(shell echo -e "${PACKAGE_INFO}" | sed -rn 's/^ *package_folder: *(.*)$$/\1/p'))
+	$(eval PACKAGE_DATE := $(shell echo -e "${PACKAGE_INFO}" | sed -rn 's/^ *Creation date: *(.*)$$/\1/p'))
+
+status: parse-info
 	# Show the *approximate* status of each package in the cloe workspace.
 	#
 	#   This lets you know whether a package is in editable mode or not,
@@ -150,6 +180,13 @@ info-channel:
 
 info-fqn:
 	echo ${PACKAGE_FQN}
+
+info: parse-info
+	if [ -z "${PACKAGE_INFO}" ]; then \
+		echo "Errors occurred, no output available."; \
+	else \
+		echo ${PACKAGE_INFO}; \
+	fi
 
 # CONFIGURATION TARGETS -------------------------------------------------------
 .PHONY: editable uneditable
@@ -196,14 +233,10 @@ download:
 	#
 	#   See: https://docs.conan.io/en/latest/mastering/policies.html
 	#
-	conan create . ${PACKAGE_FQN} \
-		--build=never \
-		${CONAN_OPTIONS} || \
-	conan create . ${PACKAGE_FQN} \
-		--build=${BUILD_POLICY} --build=${PACKAGE_NAME} \
-		${CONAN_OPTIONS}
+	conan create . ${PACKAGE_FQN} --build=never ${ALL_OPTIONS} || \
+	conan create . ${PACKAGE_FQN} --build=${BUILD_POLICY} --build=${PACKAGE_NAME} ${ALL_OPTIONS}
 
-package:
+package: ${BUILD_LOCKFILE}
 	# Build the package in Conan cache unconditionally.
 	#
 	#   Conan will retrieve and build all dependencies based on the build policy.
@@ -212,29 +245,24 @@ package:
 	#   See: https://docs.conan.io/en/latest/mastering/policies.html
 	#
 	conan create . ${PACKAGE_FQN} \
-		--build=${BUILD_POLICY} --build=${PACKAGE_NAME} \
-		${CONAN_OPTIONS}
+		--build=${BUILD_POLICY} --build=${PACKAGE_NAME} ${ALL_OPTIONS}
 
-package-all:
+package-all: ${BUILD_LOCKFILE}
 	# Build the package in Conan cache unconditionally.
 	#
 	#   Conan will retrieve and build all dependencies unconditionally.
 	#   Note that this cannot be called if the package is currently in editable mode.
 	#
-	conan create . ${PACKAGE_FQN} \
-		--build \
-		${CONAN_OPTIONS}
+	conan create . ${PACKAGE_FQN} --build ${ALL_OPTIONS}
 
-package-outdated:
+package-outdated: ${BUILD_LOCKFILE}
 	# Build the package in Conan cache if it is outdated.
 	#
 	#   Note that this does not take dependencies of ${PACKAGE_NAME} into account.
 	#   Rebuilds will occur if package info has changed or a hash of the source
 	#   code changes. Timestamps are not taken into account.
 	#
-	conan create . ${PACKAGE_FQN} \
-		--build=outdated \
-		${CONAN_OPTIONS}
+	conan create . ${PACKAGE_FQN} --build=outdated ${ALL_OPTIONS}
 
 purge:
 	# Remove all instances of this package in the Conan cache.
@@ -245,7 +273,7 @@ purge:
 	#
 	-conan remove -f ${PACKAGE_FQN}
 
-list:
+list: parse-info
 	# List all files in the Conan cache package directory.
 	#
 	@tree ${PACKAGE_DIR}
@@ -255,13 +283,12 @@ list:
 all: ${SOURCE_DIR} ${BUILD_CONANINFO}
 	# Build the package in-source.
 	#
-	mkdir -p ${BUILD_DIR}
-	conan build . --source-folder=${SOURCE_DIR} --build-folder=${BUILD_DIR}
+	conan build . --source-folder="${SOURCE_DIR}" --build-folder="${BUILD_DIR}"
 
 clean:
 	# Clean the build directory and Python cache files.
 	#
-	rm -rf ${BUILD_DIR}
+	rm -rf "${BUILD_DIR}"
 	rm -rf __pycache__
 	if ${CLEAN_SOURCE_DIR}; then \
 		rm -rf ${SOURCE_DIR}; \
@@ -276,8 +303,8 @@ test:
 	#
 	#   If no tests are available, this will simply return true.
 	#
-	@if [ -f ${BUILD_DIR}/CTestTestfile.cmake ]; then \
-		cd ${BUILD_DIR} && ctest; \
+	@if [ -f "${BUILD_DIR}"/CTestTestfile.cmake ]; then \
+		cd "${BUILD_DIR}" && ctest; \
 	else \
 		true; \
 	fi
@@ -290,8 +317,8 @@ export-pkg:
 	#   binaries available to Conan but not the source.
 	#
 	#   Note that this does not require the package to be editable.
-	conan export-pkg . ${PACKAGE_FQN} \
-		--build-folder=${BUILD_DIR}
+	#
+	conan export-pkg . ${PACKAGE_FQN} --build-folder="${BUILD_DIR}"
 
 ${SOURCE_DIR}:
 	# Copy source to an external source directory.
@@ -300,23 +327,20 @@ ${SOURCE_DIR}:
 	#   SOURCE_DIR is identical to the current directory.
 	#
 	[ "$(shell readlink -f "${SOURCE_DIR}")" != "$(shell readlink -f .)" ]
-	conan source . --source-folder=${SOURCE_DIR}
+	conan source . --source-folder="${SOURCE_DIR}"
+
+${BUILD_DIR}:
+	mkdir -p "${BUILD_DIR}"
 
 ${SOURCE_CMAKELISTS}: ${SOURCE_DIR}
 
-${BUILD_CONANINFO}: ${SOURCE_CONANFILE}
+${BUILD_CONANINFO}: ${SOURCE_CONANFILE} ${BUILD_DIR} ${BUILD_LOCKFILE}
 	# Install package dependencies and prepare in-source build.
 	#
-	mkdir -p ${BUILD_DIR}
-	conan install . ${PACKAGE_FQN} \
-		--install-folder=${BUILD_DIR} \
-		-s ${PACKAGE_NAME}:build_type=${BUILD_TYPE} \
-		--build=${BUILD_POLICY} \
-		${CONAN_OPTIONS}
+	conan install . ${PACKAGE_FQN} --install-folder="${BUILD_DIR}" --build=${BUILD_POLICY} ${ALL_OPTIONS}
 	touch ${BUILD_CONANINFO}
 
-${BUILD_CMAKECACHE}: ${BUILD_CONANINFO} ${SOURCE_CMAKELISTS}
+${BUILD_CMAKECACHE}: ${SOURCE_CMAKELISTS} ${BUILD_CONANINFO}
 	# Configure in-source build with CMake.
 	#
-	mkdir -p ${BUILD_DIR}
-	conan build --configure . --source-folder=${SOURCE_DIR} --build-folder=${BUILD_DIR}
+	conan build --configure . --source-folder="${SOURCE_DIR}" --build-folder="${BUILD_DIR}"

--- a/Makefile.package
+++ b/Makefile.package
@@ -60,8 +60,12 @@ PACKAGE_FQN     := ${PACKAGE_NAME}/${PACKAGE_VERSION}@${PACKAGE_CHANNEL}
 # only apply to local builds.
 #
 # This can be one of: None, Debug, Release, RelWithDebInfo, MinSizeRel
-BUILD_TYPE := RelWithDebInfo
+BUILD_TYPE :=
+ifneq "${BUILD_TYPE}" ""
 BUILD_TYPE_OPTION := -s ${PACKAGE_NAME}:build_type=${BUILD_TYPE}
+else
+BUILD_TYPE_OPTION :=
+endif
 
 # These options can be set to influence package and configure.
 CONAN_OPTIONS :=

--- a/engine/conanfile.py
+++ b/engine/conanfile.py
@@ -27,6 +27,14 @@ class CloeEngine(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires("boost/[>=1.65.1]"),
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")

--- a/fable/conanfile.py
+++ b/fable/conanfile.py
@@ -34,6 +34,14 @@ class Fable(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def build_requirements(self):
         if self.options.test:
             self.build_requires("gtest/[~=1.10]")

--- a/models/conanfile.py
+++ b/models/conanfile.py
@@ -34,6 +34,14 @@ class CloeModels(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
 

--- a/oak/conanfile.py
+++ b/oak/conanfile.py
@@ -33,6 +33,14 @@ class CloeOak(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
 

--- a/plugins/basic/conanfile.py
+++ b/plugins/basic/conanfile.py
@@ -29,6 +29,14 @@ class CloeControllerBasic(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
         self.requires(f"cloe-models/{self.version}@cloe/develop")

--- a/plugins/gndtruth_extractor/conanfile.py
+++ b/plugins/gndtruth_extractor/conanfile.py
@@ -25,6 +25,14 @@ class CloeControllerGndtruthExtractor(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
         self.requires(f"cloe-models/{self.version}@cloe/develop")

--- a/plugins/minimator/conanfile.py
+++ b/plugins/minimator/conanfile.py
@@ -23,6 +23,14 @@ class CloeSimulatorMinimator(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
         self.requires(f"cloe-models/{self.version}@cloe/develop")

--- a/plugins/mocks/conanfile.py
+++ b/plugins/mocks/conanfile.py
@@ -23,6 +23,14 @@ class CloeControllerMocks(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
         self.requires(f"cloe-models/{self.version}@cloe/develop")

--- a/plugins/noisy_sensor/conanfile.py
+++ b/plugins/noisy_sensor/conanfile.py
@@ -25,6 +25,14 @@ class CloeComponentNoisySensor(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
         self.requires(f"cloe-models/{self.version}@cloe/develop")

--- a/plugins/speedometer/conanfile.py
+++ b/plugins/speedometer/conanfile.py
@@ -23,6 +23,14 @@ class CloeComponentKmph(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
         self.requires(f"cloe-models/{self.version}@cloe/develop")

--- a/plugins/virtue/conanfile.py
+++ b/plugins/virtue/conanfile.py
@@ -23,6 +23,14 @@ class CloeControllerVirtue(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
         self.requires(f"cloe-models/{self.version}@cloe/develop")

--- a/plugins/vtd/conanfile.py
+++ b/plugins/vtd/conanfile.py
@@ -36,6 +36,14 @@ class CloeSimulatorVTD(ConanFile):
     _setup_folder = "contrib/setups"
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"cloe-runtime/{self.version}@cloe/develop")
         self.requires(f"cloe-models/{self.version}@cloe/develop")

--- a/runtime/conanfile.py
+++ b/runtime/conanfile.py
@@ -39,6 +39,14 @@ class CloeRuntime(ConanFile):
 
     _cmake = None
 
+    def set_version(self):
+        version_file = Path(self.recipe_folder) / "../VERSION"
+        if version_file.exists():
+            self.version = tools.load(version_file).strip()
+        else:
+            git = tools.Git(folder=self.recipe_folder)
+            self.version = git.run("describe --dirty=-dirty")[1:]
+
     def requirements(self):
         self.requires(f"fable/{self.version}@cloe/develop")
 


### PR DESCRIPTION
This is an alternative implementation for lockfiles that I feel is more flexible and also more easily removed should the need arise.

I have tested it in several different constellations and find it very valuable.

Changelog:

- New: Makefile targets accept argument `LOCKFILE_SOURCE` to specify a profile to build a package to. This is compatible with all relevant make targets, such as `package` and `all`.
- Fixed: Makefile checks that option arguments are 0 or 1, such as `WITH_VTD`. 
- Fixed: Makefile `status` target reflects status of packages as they relate to `cloe` metapackage.