### PR TITLE
Matthias/extend cloe data model with actuators

### DIFF
--- a/engine/src/plugins/nop_simulator.cpp
+++ b/engine/src/plugins/nop_simulator.cpp
@@ -29,10 +29,13 @@
 
 #include <cloe/component/brake_sensor.hpp>       // for NopBrakeSensor
 #include <cloe/component/ego_sensor.hpp>         // for NopEgoSensor
+#include <cloe/component/gearbox_actuator.hpp>   // for GearboxActuator
 #include <cloe/component/lane_sensor.hpp>        // for NopLaneSensor
 #include <cloe/component/latlong_actuator.hpp>   // for LatLongActuator
 #include <cloe/component/object_sensor.hpp>      // for NopObjectSensor
+#include <cloe/component/pedal_actuator.hpp>     // for PedalActuator
 #include <cloe/component/powertrain_sensor.hpp>  // for NopPowertrainSensor
+#include <cloe/component/steering_actuator.hpp>  // for SteeringActuator
 #include <cloe/component/steering_sensor.hpp>    // for NopSteeringSensor
 #include <cloe/component/wheel_sensor.hpp>       // for NopWheelSensor
 #include <cloe/handler.hpp>                      // for ToJson
@@ -68,6 +71,12 @@ struct NopVehicle : public Vehicle {
                         CloeComponent::DEFAULT_WORLD_SENSOR);
     this->new_component(new LatLongActuator(),
                         CloeComponent::DEFAULT_LATLONG_ACTUATOR);
+    this->new_component(new GearboxActuator(),
+                        CloeComponent::DEFAULT_GEARBOX_ACTUATOR);
+    this->new_component(new PedalActuator(),
+                        CloeComponent::DEFAULT_PEDAL_ACTUATOR);
+    this->new_component(new SteeringActuator(),
+                        CloeComponent::DEFAULT_STEERING_ACTUATOR);
     this->new_component(new NopLaneSensor(),
                         CloeComponent::GROUNDTRUTH_LANE_SENSOR,
                         CloeComponent::DEFAULT_LANE_SENSOR);

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(${target}
     # find src -type f -name "*.cpp" \! -name "*_test.cpp"
     src/cloe/component/lane_boundary.cpp
     src/cloe/component/utility/ego_sensor_canon.cpp
+    src/cloe/component/utility/steering_utils.cpp
     src/cloe/utility/actuation_state.cpp
 )
 add_library(${alias} ALIAS ${target})
@@ -46,7 +47,9 @@ if(BuildTests)
 
     add_executable(test-models
         # find src -type f -name "*_test.cpp"
+        src/cloe/component/gearbox_actuator_test.cpp
         src/cloe/component/latlong_actuator_test.cpp
+        src/cloe/component/utility/steering_utils_test.cpp
         src/cloe/utility/actuation_level_test.cpp
     )
     set_target_properties(test-models PROPERTIES

--- a/models/include/cloe/component/actuator.hpp
+++ b/models/include/cloe/component/actuator.hpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/actuator.hpp
+ */
+
+#pragma once
+#ifndef CLOE_COMPONENT_ACTUATOR_HPP_
+#define CLOE_COMPONENT_ACTUATOR_HPP_
+
+#include <boost/optional.hpp>  // for optional
+#include <cloe/component.hpp>  // for Component
+#include <fable/json.hpp>      // for Json
+
+namespace cloe {
+
+template <typename T = double>
+class Actuator : public Component {
+ public:
+  using Component::Component;
+  virtual ~Actuator() noexcept = default;
+
+  virtual void set(T a) { target_ = a; }
+  virtual bool is_set() { return static_cast<bool>(target_); }
+  virtual T get() { return *target_; }
+
+  Json active_state() const override { return Json{{"target", target_}}; }
+
+  Duration process(const Sync& sync) override {
+    auto t = Component::process(sync);
+    target_.reset();
+    return t;
+  }
+
+  void reset() override {
+    Component::reset();
+    target_.reset();
+  }
+
+ protected:
+  boost::optional<T> target_;
+};
+
+}  // namespace cloe
+
+#endif  // CLOE_COMPONENT_ACTUATOR_HPP_

--- a/models/include/cloe/component/gearbox_actuator.hpp
+++ b/models/include/cloe/component/gearbox_actuator.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/gearbox_actuator.hpp
+ */
+
+#pragma once
+#ifndef CLOE_COMPONENT_GEARBOX_ACTUATOR_HPP_
+#define CLOE_COMPONENT_GEARBOX_ACTUATOR_HPP_
+
+#include <cloe/component/actuator.hpp>  // for Actuator
+#include <fable/json.hpp>               // for Json
+
+namespace cloe {
+
+struct GearboxRequest {
+  /* 
+   * Holds the requested gear selector position. 
+   *
+   * The sign of this field is linked to the mode of the gear
+   * - positive: driving forward (e.g. a value of 3 means to request the third gear in driving forward mode)
+   * - 0: means that the gear lever is requested to be in neutral position
+   * - negative: reverse mode (e.g. a value of -1 means the first gear in reverse mode is requested)
+   * - int8_t max: means that the transmission is in parking position (can be accessed via std::numeric_limits<int8_t>::max())
+   */
+  int8_t gear_selector{0};
+
+  friend void to_json(Json& j, const GearboxRequest& g) {
+    j = Json{{"gear_selector", g.gear_selector}};
+  }
+};
+
+class GearboxActuator : public Actuator<GearboxRequest> {
+ public:
+  using Actuator::Actuator;
+  GearboxActuator() : Actuator("gearbox_actuator") {}
+  virtual ~GearboxActuator() noexcept = default;
+};
+
+}  // namespace cloe
+
+#endif  // CLOE_COMPONENT_GEARBOX_ACTUATOR_HPP_

--- a/models/include/cloe/component/latlong_actuator.hpp
+++ b/models/include/cloe/component/latlong_actuator.hpp
@@ -30,6 +30,7 @@
 #include <fable/json/with_boost.hpp>  // for to_json
 
 #include <cloe/component.hpp>                // for Component, Json
+#include <cloe/component/actuator.hpp>       // for Actuator
 #include <cloe/utility/actuation_level.hpp>  // for ActuationLevel
 
 namespace cloe {
@@ -114,33 +115,6 @@ class LatLongActuator : public Component {
   utility::ActuationLevel level_;
   boost::optional<double> target_acceleration_;
   boost::optional<double> target_steering_angle_;
-};
-
-template <typename T = double>
-class Actuator : public Component {
- public:
-  using Component::Component;
-  virtual ~Actuator() noexcept = default;
-
-  virtual void set(T a) { target_ = a; }
-  virtual bool is_set() { return static_cast<bool>(target_); }
-  virtual T get() { return *target_; }
-
-  Json active_state() const override { return Json{"target", target_}; }
-
-  Duration process(const Sync& sync) override {
-    auto t = Component::process(sync);
-    target_.reset();
-    return t;
-  }
-
-  void reset() override {
-    Component::reset();
-    target_.reset();
-  }
-
- protected:
-  boost::optional<T> target_;
 };
 
 class LongActuator : public Actuator<double> {

--- a/models/include/cloe/component/pedal_actuator.hpp
+++ b/models/include/cloe/component/pedal_actuator.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/pedal_actuator.hpp
+ */
+
+#pragma once
+#ifndef CLOE_COMPONENT_PEDAL_ACTUATOR_HPP_
+#define CLOE_COMPONENT_PEDAL_ACTUATOR_HPP_
+
+#include <cloe/component/actuator.hpp>  // for Actuator
+#include <fable/json.hpp>               // for Json
+
+namespace cloe {
+
+struct PedalRequest {
+  /* 
+   * Requested status of the gas pedal with no unit.
+   *
+   * The range goes from 0 (unpressed) to 1 (fully pressed).
+   */
+  double gas_pedal_position{0.0};
+
+  /* 
+   * Requested status of the brake pedal with no unit.
+   *
+   * The range goes from 0 (unpressed) to 1 (fully pressed).
+   */
+  double brake_pedal_position{0.0};
+
+  friend void to_json(Json& j, const PedalRequest& p) {
+    j = Json{
+        {"gas_pedal_position", p.gas_pedal_position},
+        {"brake_pedal_position", p.brake_pedal_position},
+    };
+  }
+};
+
+class PedalActuator : public Actuator<PedalRequest> {
+ public:
+  using Actuator::Actuator;
+  PedalActuator() : Actuator("pedal_actuator") {}
+  virtual ~PedalActuator() noexcept = default;
+};
+
+}  // namespace cloe
+
+#endif  // CLOE_COMPONENT_PEDAL_ACTUATOR_HPP_

--- a/models/include/cloe/component/steering_actuator.hpp
+++ b/models/include/cloe/component/steering_actuator.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/steering_actuator.hpp
+ */
+
+#pragma once
+#ifndef CLOE_COMPONENT_STEERING_ACTUATOR_HPP_
+#define CLOE_COMPONENT_STEERING_ACTUATOR_HPP_
+
+#include <cloe/component/actuator.hpp>  // for Actuator
+#include <fable/json.hpp>               // for Json
+
+namespace cloe {
+
+struct SteeringRequest {
+  /**
+   * Front center wheel angle with regards to z-Axis in [radians].
+   */
+  double steering_angle_front{0.0};
+
+  /** 
+   * Rear center wheel angle with regards to z-Axis in [radians].
+   */
+  double steering_angle_rear{0.0};
+
+  friend void to_json(Json& j, const SteeringRequest& s) {
+    j = Json{
+        {"steering_angle_front", s.steering_angle_front},
+        {"steering_angle_rear", s.steering_angle_rear},
+    };
+  }
+};
+
+class SteeringActuator : public Actuator<SteeringRequest> {
+ public:
+  using Actuator::Actuator;
+  SteeringActuator() : Actuator("steering_actuator") {}
+  virtual ~SteeringActuator() noexcept = default;
+};
+
+}  // namespace cloe
+
+#endif  // CLOE_COMPONENT_STEERING_ACTUATOR_HPP_

--- a/models/include/cloe/component/utility/steering_utils.hpp
+++ b/models/include/cloe/component/utility/steering_utils.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/utility/steering_utils.hpp
+ */
+
+#pragma once
+#ifndef CLOE_COMPONENT_UTILITY_STEERING_UTILS_HPP_
+#define CLOE_COMPONENT_UTILITY_STEERING_UTILS_HPP_
+
+namespace cloe {
+namespace utility {
+
+struct Geometry {
+  /// Distance between the front and the rear axle in [m].
+  double wheel_base{0.0};
+
+  /// Distance between the left wheel and the right wheel in [m].
+  double track_base{0.0};
+};
+
+enum class WheelId : unsigned int { FrontLeft = 0, FrontRight, RearLeft, RearRight };
+
+/**
+ * This function translates a steering angle from the center of the axle to the individual steering angle of a wheel.
+ *
+ * This function is based on the Ackermann steering geometry, see [https://en.wikipedia.org/wiki/Ackermann_steering_geometry, accessed 28.10.2022]
+ * The calculation only works for the following assumptions, as it assumes that the centre of rotation is on the same level with the rear wheels:
+ *     - low speed
+ *     - no rear steering
+ * Detailed explanations can be found in basic vehicle dynamics literature, e.g. chapter 4.2 of the Steering Handbook 
+ * by Harrer and Pfeffer [https://link.springer.com/book/10.1007/978-3-319-05449-0]
+ * 
+ * The function needs a wheel_base, a track_base (both stored in Geometry), the wheel_id and the steering_angle in the center of the axle.
+ * The wheel_id is the ID you want to calculate the angle for, i.e. either FrontLeft or FrontRight.
+ * The function returns the value of the steering_angle of the requested wheel.
+ */
+double calculate_wheel_angle(const Geometry& geometry, WheelId wheel_id, double steering_angle);
+
+}  // namespace utility
+}  // namespace cloe
+
+#endif  // CLOE_COMPONENT_UTILITY_STEERING_UTILS_HPP_

--- a/models/include/cloe/models.hpp
+++ b/models/include/cloe/models.hpp
@@ -59,6 +59,9 @@ enum class CloeComponent {
   DEFAULT_LONG_ACTUATOR,
   DEFAULT_LAT_ACTUATOR,
   DEFAULT_LATLONG_ACTUATOR,
+  DEFAULT_GEARBOX_ACTUATOR,
+  DEFAULT_PEDAL_ACTUATOR,
+  DEFAULT_STEERING_ACTUATOR,
 };
 
 // clang-format off
@@ -90,6 +93,9 @@ ENUM_SERIALIZATION(CloeComponent, ({
   {CloeComponent::DEFAULT_LONG_ACTUATOR, "cloe::default_long_actuator"},
   {CloeComponent::DEFAULT_LAT_ACTUATOR, "cloe::default_lat_actuator"},
   {CloeComponent::DEFAULT_LATLONG_ACTUATOR, "cloe::default_latlong_actuator"},
+  {CloeComponent::DEFAULT_GEARBOX_ACTUATOR, "cloe::default_gearbox_actuator"},
+  {CloeComponent::DEFAULT_PEDAL_ACTUATOR, "cloe::default_pedal_actuator"},
+  {CloeComponent::DEFAULT_STEERING_ACTUATOR, "cloe::default_steering_actuator"},
 }))
 // clang-format on
 

--- a/models/src/cloe/component/gearbox_actuator_test.cpp
+++ b/models/src/cloe/component/gearbox_actuator_test.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/gearbox_actutator_test.cpp
+ * \see  cloe/component/gearbox_actuator.hpp
+ */
+
+#include <gtest/gtest.h>
+
+#include <cloe/component/gearbox_actuator.hpp>
+
+TEST(cloe_gearbox_actuation, is_set) {
+  cloe::GearboxActuator gearboxActuator{};
+
+  // expect that the optional member is not set
+  EXPECT_FALSE(gearboxActuator.is_set());
+
+  // set a gearbox request
+  cloe::GearboxRequest testRequest{};
+  gearboxActuator.set(testRequest);
+
+  // expect that the optional member is set
+  EXPECT_TRUE(gearboxActuator.is_set());
+
+  // reset the actuator
+  gearboxActuator.reset();
+
+  // expect that the optional member is not set
+  EXPECT_FALSE(gearboxActuator.is_set());
+}
+
+TEST(cloe_gearbox_actuation, set_values) {
+  // intialization
+  cloe::GearboxActuator gearboxActuator{};
+  cloe::GearboxRequest testRequest{};
+  int valueToTest = 3;
+
+  // set the test value
+  testRequest.gear_selector = valueToTest;
+  gearboxActuator.set(testRequest);
+
+  // expect that the actuator returns the same value as set
+  EXPECT_EQ(gearboxActuator.get().gear_selector, valueToTest);
+}

--- a/models/src/cloe/component/utility/steering_utils.cpp
+++ b/models/src/cloe/component/utility/steering_utils.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/utility/steering_utils.cpp
+ * \see  cloe/component/utility/steering_utils.hpp
+ */
+
+#include <cassert>
+#include <cmath>
+
+#include <cloe/component/utility/steering_utils.hpp>
+
+namespace cloe {
+namespace utility {
+
+double calculate_wheel_angle(const Geometry& geometry, WheelId wheel_id, double steering_angle) {
+  // check if the input values are correct
+  assert((geometry.wheel_base > 0) &&
+         "it does not make sense to call calculate_wheel_angle with a wheel_base smaller than 0");
+  assert((geometry.track_base > 0) &&
+         "it does not make sense to call calculate_wheel_angle with a track_base smaller than 0");
+  assert((wheel_id != WheelId::RearRight) &&
+         "it does not make sense to call calculate_wheel_angle for the rear right wheel");
+  assert((wheel_id != WheelId::RearLeft) &&
+         "it does not make sense to call calculate_wheel_angle for the rear left wheel");
+
+  // return 1.0 if wheel id is front left, otherwise return -1.0. This is due to the geometric relation.
+  double sign = (wheel_id == WheelId::FrontLeft ? 1.0 : -1.0);
+
+  // calculate tangent of the provided steering angle as an intermediate step.
+  double tangent_steering_angle = std::tan(steering_angle);
+
+  // This equation is the divisor part of the geometric relation for low speeds.
+  double divisor =
+      (1 - sign * 0.5 * tangent_steering_angle * geometry.track_base / geometry.wheel_base);
+
+  return std::atan(tangent_steering_angle / divisor);
+}
+
+}  // namespace utility
+}  // namespace cloe

--- a/models/src/cloe/component/utility/steering_utils_test.cpp
+++ b/models/src/cloe/component/utility/steering_utils_test.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/utility/steering_utils_test.cpp
+ * \see  cloe/component/utility/steering_utils.cpp
+ */
+
+#include <gtest/gtest.h>
+#include <cloe/component/utility/steering_utils.hpp>
+
+TEST(steering_utils, test_front_left) {
+  using namespace cloe::utility;
+  using namespace std;
+
+  // values of tuple: Geometry(wheel_base, track_base), center of steering angle,
+  // upper limit of expected value, lower limit of expected value
+  vector<tuple<Geometry, double, double, double>> test_vector = {
+      make_tuple(Geometry{3.0, 1.5}, 0.0, 0.01, 0.00),
+      make_tuple(Geometry{3.0, 1.5}, 0.7853, 0.95, 0.7853),   // pi/4 as input
+      make_tuple(Geometry{3.0, 3.0}, 0.7853, 1.15, 0.7853),   // pi/4 as input
+      make_tuple(Geometry{4.0, 1.5}, -0.7853, -0.6, -0.7853)  // -pi/4 as input
+  };
+
+  for (auto test_tuple : test_vector) {
+    // call the function under test for the different input tuples for FrontLeft wheel
+    double result =
+        calculate_wheel_angle(get<0>(test_tuple), WheelId::FrontLeft, get<1>(test_tuple));
+
+    EXPECT_LE(result, get<2>(test_tuple));
+    EXPECT_GE(result, get<3>(test_tuple));
+  }
+}
+
+TEST(steering_utils, test_front_right) {
+  using namespace cloe::utility;
+  using namespace std;
+
+  // values of tuple: Geometry(wheel_base, track_base), center of steering angle,
+  // upper limit of expected value, lower limit of expected value
+  vector<tuple<Geometry, double, double, double>> test_vector = {
+      make_tuple(Geometry{3.0, 1.5}, 0.0, 0.01, 0.00),
+      make_tuple(Geometry{3.0, 1.5}, 0.7853, 0.7853, 0.6),    // pi/4 as input
+      make_tuple(Geometry{3.0, 3.0}, 0.7853, 0.7853, 0.55),   // pi/4 as input
+      make_tuple(Geometry{4.0, 1.5}, -0.7853, -0.7853, -0.9)  // -pi/4 as input
+  };
+
+  for (auto test_tuple : test_vector) {
+    // call the function under test for the different input tuples for FrontRight wheel
+    double result =
+        calculate_wheel_angle(get<0>(test_tuple), WheelId::FrontRight, get<1>(test_tuple));
+
+    EXPECT_LE(result, get<2>(test_tuple));
+    EXPECT_GE(result, get<3>(test_tuple));
+  }
+}
+
+TEST(steering_utils, death_test_assertion) {
+  using namespace cloe::utility;
+  using namespace std;
+
+  // values of tuple: Geometry, center steering angle
+  vector<tuple<Geometry, double>> test_vector = {
+      make_tuple(Geometry{-1.0, 1.5}, 0.0),     // negative wheel_base as input
+      make_tuple(Geometry{3.0, -1.0}, 0.7853),  // negative track_base as input
+      make_tuple(Geometry{3.0, 1.5}, 0.5)       // correct input in terms of geometry
+  };
+
+#ifndef NDEBUG
+  // expect that the assert is triggered for test_vector[0] as wheel_base is negative.
+  EXPECT_DEATH(
+      calculate_wheel_angle(get<0>(test_vector[0]), WheelId::FrontRight, get<1>(test_vector[0])),
+      "");
+
+  // expect that the assert is triggered for test_vector[1] as track_base is negative.
+  EXPECT_DEATH(
+      calculate_wheel_angle(get<0>(test_vector[1]), WheelId::FrontRight, get<1>(test_vector[1])),
+      "");
+
+  // expect that the assert is triggered for WheelId::RearLeft as input
+  EXPECT_DEATH(
+      calculate_wheel_angle(get<0>(test_vector[2]), WheelId::RearLeft, get<1>(test_vector[2])), "");
+
+  // expect that the assert is triggered for WheelId::RearRight as input
+  EXPECT_DEATH(
+      calculate_wheel_angle(get<0>(test_vector[2]), WheelId::RearRight, get<1>(test_vector[2])),
+      "");
+
+#endif
+}


### PR DESCRIPTION
- this pr suggests an extension of the cloe data model for actuators (similar as the one for the "ego sensors")
- i found it pretty useful to reuse the templated Actuator class. and in order to reuse it, I moved it out of latlong_actuator.hpp.
- for the data type hold by the "simple" actuators - such as the gearboxactuator - i chose to create a new struct GearboxRequest and pass that as template type to Actuator instead of passing a simple integer which it currently holds. my main argument is here that by using the separate struct "gearbox request" i can also describe the member value precisely in the detailed design.

It will most like conflict with that other PR, but i will resolve the conflict then, depending on what goes in first. and i found it better suitable to have two separated PRs in order to have smaller PRs, separate discussions etc.