### PR TITLE
vtd: add git describe to profile_default

### DIFF
--- a/optional/vtd/tests/profile_default.py
+++ b/optional/vtd/tests/profile_default.py
@@ -25,6 +25,8 @@ class CloeTest(ConanFile):
             if version_file.exists():
                 self.version = self.project_version(version_path)
                 return
+        git = tools.Git(folder=self.recipe_folder)
+        self.version = git.run("describe --dirty=-dirty")[1:]
 
     def requirements(self):
         self.requires(f"cloe-engine/{self.version}@cloe/develop")


### PR DESCRIPTION
If no VERSION is explicitly set, use the git describe version tag.
