### PR TITLE
Add  vehicle dynamics model support

### DIFF
--- a/engine/tests/test_engine_json_schema.json
+++ b/engine/tests/test_engine_json_schema.json
@@ -122,6 +122,10 @@
                     },
                     "type": "object"
                   },
+                  "driver_request": {
+                    "description": "component providing driver request",
+                    "type": "string"
+                  },
                   "lka": {
                     "additionalProperties": false,
                     "description": "LKA configuration",

--- a/models/include/cloe/component/driver_request.hpp
+++ b/models/include/cloe/component/driver_request.hpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/driver_request.hpp
+ */
+
+#pragma once
+#ifndef CLOE_COMPONENT_DRIVER_REQUEST_HPP_
+#define CLOE_COMPONENT_DRIVER_REQUEST_HPP_
+
+#include <cloe/component.hpp>  // for Component, Json
+
+namespace cloe {
+
+class DriverRequest : public Component {
+ public:
+  using Component::Component;
+  DriverRequest() : Component("driver_request") {}
+  virtual ~DriverRequest() noexcept = default;
+
+  /**
+   * Return driver-requested acceleration in [m/s^2].
+   */
+  virtual boost::optional<double> acceleration() const = 0;
+
+  /**
+   * Return true if acceleration request is available for this step.
+   */
+  virtual bool has_acceleration() const = 0;
+
+  /**
+   * Return driver-requested steering angle at front wheels in [rad].
+   */
+  virtual boost::optional<double> steering_angle() const = 0;
+
+  /**
+   * Return true if steering angle request is available for this step.
+   */
+  virtual bool has_steering_angle() const = 0;
+
+  /**
+   * Return sensor state as JSON.
+   */
+  Json active_state() const override {
+    return Json{
+        {"acceleration", acceleration()},
+        {"steering_angle", steering_angle()},
+    };
+  }
+};
+
+/**
+ * NopDriverRequest is an example no-op implementation of DriverRequest.
+ */
+class NopDriverRequest : public DriverRequest {
+ public:
+  using DriverRequest::DriverRequest;
+  NopDriverRequest() : DriverRequest("nop_driver_request") {}
+  virtual ~NopDriverRequest() noexcept {};
+
+  boost::optional<double> acceleration() const override { return acceleration_; }
+  bool has_acceleration() const override { return static_cast<bool>(acceleration_); }
+
+  boost::optional<double> steering_angle() const override { return steering_angle_; }
+  bool has_steering_angle() const override { return static_cast<bool>(steering_angle_); }
+
+  Duration process(const Sync& sync) override {
+    auto t = DriverRequest::process(sync);
+    acceleration_.reset();
+    steering_angle_.reset();
+    return t;
+  }
+
+  void reset() override {
+    DriverRequest::reset();
+    acceleration_.reset();
+    steering_angle_.reset();
+  }
+
+ protected:
+  boost::optional<double> acceleration_{0.0};
+  boost::optional<double> steering_angle_{0.0};
+};
+
+}  // namespace cloe
+
+#endif  // CLOE_COMPONENT_DRIVER_REQUEST_HPP_

--- a/models/include/cloe/component/latlong_actuator.hpp
+++ b/models/include/cloe/component/latlong_actuator.hpp
@@ -45,17 +45,17 @@ class LatLongActuator : public Component {
    * Set the vehicle target acceleration in m/s^2.
    * The time that the vehicle requires to reach this acceleration is undefined.
    */
-  void set_acceleration(double a) {
+  virtual void set_acceleration(double a) {
     target_acceleration_ = a;
     level_.set_long();
   }
 
-  boost::optional<double> acceleration() const { return target_acceleration_; }
+  virtual boost::optional<double> acceleration() { return target_acceleration_; }
 
   /**
    * Return true if set_acceleration was called for the current step.
    */
-  bool is_acceleration() const { return static_cast<bool>(target_acceleration_); }
+  virtual bool is_acceleration() const { return static_cast<bool>(target_acceleration_); }
 
   /**
    * Set the target steering angle of the wheels in rad.
@@ -63,17 +63,17 @@ class LatLongActuator : public Component {
    * In most cases, the front left wheel defines the angle, and the time to target
    * steering angle is zero.
    */
-  void set_steering_angle(double a) {
+  virtual void set_steering_angle(double a) {
     target_steering_angle_ = a;
     level_.set_lat();
   }
 
-  boost::optional<double> steering_angle() const { return target_steering_angle_; }
+  virtual boost::optional<double> steering_angle() { return target_steering_angle_; }
 
   /**
    * Return true if set_target_steering_angle was called for the current step.
    */
-  bool is_steering_angle() const { return static_cast<bool>(target_steering_angle_); }
+  virtual bool is_steering_angle() const { return static_cast<bool>(target_steering_angle_); }
 
   /**
    * Return a single enum summarizing the current actuation level of control.

--- a/models/include/cloe/component/vehicle_state_model.hpp
+++ b/models/include/cloe/component/vehicle_state_model.hpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file cloe/component/vehicle_state_model.hpp
+ */
+
+#pragma once
+#ifndef CLOE_COMPONENT_VEHICLE_STATE_MODEL_HPP_
+#define CLOE_COMPONENT_VEHICLE_STATE_MODEL_HPP_
+
+#include <functional>  // for function
+
+#include <boost/optional.hpp>  // for optional<>
+
+#include <fable/json/with_boost.hpp>  // for to_json
+#include <cloe/component.hpp>         // for Component, Json
+#include <cloe/component/object.hpp>  // for Object
+
+namespace cloe {
+
+class VehicleStateModel : public Component {
+ public:
+  using Component::Component;
+  VehicleStateModel() : Component("vehicle_state") {}
+  virtual ~VehicleStateModel() noexcept = default;
+
+  /**
+   * Set the ego vehicle state corresponding to the end of the current step.
+   */
+  virtual void set_vehicle_state(const Object& obj) { vehicle_state_ = obj; }
+
+  /**
+   * Get the ego vehicle state at the end of the current step. Note that
+   * vehicle_state() may invoke set_vehicle_state() by calling
+   * vehicle_state_callback_().
+   */
+  const boost::optional<Object>& vehicle_state() {
+    if (vehicle_state_callback_) {
+      vehicle_state_callback_();
+    }
+    return vehicle_state_;
+  }
+
+  /**
+   * Return true if set_vehicle_state was called for the current step. Note that
+   * is_vehicle_state() may invoke set_vehicle_state() by calling
+   * vehicle_state_callback_().
+   */
+  bool is_vehicle_state() {
+    if (vehicle_state_callback_) {
+      vehicle_state_callback_();
+    }
+    return static_cast<bool>(vehicle_state_);
+  }
+
+  /**
+   * Register callback function that will invoke set_vehicle_state().
+   */
+  void register_vehicle_state_callback(const std::function<void(void)>& c) {
+    vehicle_state_callback_ = c;
+  }
+
+  /**
+   * Write the JSON representation of the vehicle state into j.
+   *
+   * Currently, the API is unstable, because we don't have access to any real
+   * data.
+   */
+  Json active_state() const override {
+    return Json{
+        {"vehicle_state", vehicle_state_},
+    };
+  }
+
+  Duration process(const Sync& sync) override {
+    auto t = Component::process(sync);
+    vehicle_state_.reset();
+    return t;
+  }
+
+  void reset() override {
+    Component::reset();
+    vehicle_state_.reset();
+  }
+
+ protected:
+  /**
+   * Vehicle state determined by a vehicle dynamics model.
+   *
+   * Contains object pose, velocity, acceleration, angular_velocity in world coordinates.
+   */
+  boost::optional<Object> vehicle_state_;
+
+  /**
+   * Callback function that is invoked when access to the ego vehicle target
+   * state is requested (by calling is_vehicle_state() or vehicle_state()).
+   *
+   * The main use case for the callback is to update the ego vehicle state using
+   * an actuator and/or vehicle dynamics model external of the simulator. Then,
+   * the callback could implement the following:
+   *  - Update the external model with the latest simulator state
+   *  - Trigger the time stepping of the external model
+   *  - Invoke set_vehicle_state() to update LatLongActuator
+   *
+   * Note that the callback function must ensure that repeated invocation within
+   * the same time step does not lead to unintended behavior.
+   */
+  std::function<void(void)> vehicle_state_callback_;
+};
+
+}  // namespace cloe
+
+#endif  // CLOE_COMPONENT_VEHICLE_STATE_MODEL_HPP_

--- a/models/include/cloe/utility/geometry.hpp
+++ b/models/include/cloe/utility/geometry.hpp
@@ -52,11 +52,34 @@ inline Eigen::Isometry3d pose_from_rotation_translation(const Eigen::Quaterniond
 }
 
 /**
- * Change a point's frame of reference.
- * Both the point and the child frame need to have the same parent frame.
+ * Compute the roll, pitch and yaw angles from a given pose.
+ *
+ * \param pose: Pose of which the rotation matrix shall be expressed in Euler angles.
  */
-inline void transform_to_child_frame(const Eigen::Isometry3d& child_frame, Eigen::Vector3d* point) {
-  *point = child_frame.inverse() * (*point);
+inline Eigen::Vector3d get_pose_roll_pitch_yaw(const Eigen::Isometry3d& pose) {
+  return pose.rotation().matrix().eulerAngles(2, 1, 0).reverse();
+}
+
+/**
+ * Change a point's frame of reference from the parent frame to the child frame.
+ *
+ * \param child_frame: Pose of the child reference frame w.r.t. the parent frame.
+ * \param pt_vec: Point coordinate vector w.r.t. the parent frame.
+ */
+inline void transform_point_to_child_frame(const Eigen::Isometry3d& child_frame,
+                                           Eigen::Vector3d* pt_vec) {
+  *pt_vec = child_frame.inverse() * (*pt_vec);
+}
+
+/**
+ * Change a point's frame of reference from the child frame to the parent frame.
+ *
+ * \param child_frame: Pose of the child reference frame w.r.t. the parent frame.
+ * \param pt_vec_child: Point coordinate vector w.r.t. the child frame.
+ */
+inline void transform_point_to_parent_frame(const Eigen::Isometry3d& child_frame,
+                                            Eigen::Vector3d* pt_vec_child) {
+  *pt_vec_child = child_frame * (*pt_vec_child);
 }
 
 }  // namespace utility

--- a/optional/vtd/CMakeLists.txt
+++ b/optional/vtd/CMakeLists.txt
@@ -62,6 +62,7 @@ if(BUILD_TESTING)
         src/rdb_transceiver_tcp_test.cpp
         src/osi_test.cpp
         src/vtd_osi_test.cpp
+        src/vtd_data_conversion_test.cpp
     )
     set_target_properties(test-vtd-binding PROPERTIES
         CXX_STANDARD 14

--- a/optional/vtd/src/actuator_component.hpp
+++ b/optional/vtd/src/actuator_component.hpp
@@ -26,7 +26,8 @@
 
 #include <memory>  // for shared_ptr<>
 
-#include <cloe/component/latlong_actuator.hpp>  // for LatLongActuator
+#include <cloe/component/latlong_actuator.hpp>     // for LatLongActuator
+#include <cloe/component/vehicle_state_model.hpp>  // for VehicleStateModel
 
 #include "task_control.hpp"  // for TaskControl
 #include "vtd_logger.hpp"    // for vtd_logger
@@ -157,21 +158,73 @@ class VtdLatLongActuator : public VtdVehicleControl, public cloe::LatLongActuato
   cloe::utility::ActuationLevel old_level_;
 };
 
+/**
+ * VtdExternalEgoModel provides the ego state from an external model to VTD.
+ *
+ * # Usage
+ *
+ * Every VTD cycle, the following needs to be done:
+ *
+ * - `step_begin` retrieves the updated ego vehicle state from the external model
+ *    and registers the new state with the TaskControl client.
+ * - `TaskControl::add_trigger_and_send` must be called to send the information
+ *   to VTD.
+ */
+class VtdExternalEgoModel : public VtdVehicleControl, public cloe::VehicleStateModel {
+ public:
+  VtdExternalEgoModel(std::shared_ptr<TaskControl> tc, uint64_t id, const std::string& veh_name)
+      : VehicleStateModel("vtd/ego_state")
+      , task_control_(tc)
+      , vehicle_id_(id)
+      , vehicle_name_(veh_name) {}
+  virtual ~VtdExternalEgoModel() = default;
+
+  /**
+   * Add the DynObjectState package to the TaskControl.
+   *
+   * This should only be called once per simulation step. This method will not
+   * pay attention for you.  Later, when the TaskControl sends its packages,
+   * this one will be part of it.
+   */
+  void step_begin(const cloe::Sync& sync) override {
+    if (this->is_vehicle_state()) {
+      add_dyn_object_state();
+    } else if (sync.step() > 1) {
+      // During the first time step, external model has not yet been updated. Throw otherwise.
+      throw cloe::ModelError("VtdExternalEgoModel: vehicle state not set.");
     }
   }
 
-  cloe::Duration process(const cloe::Sync& sync) override { return LatLongActuator::process(sync); }
-
   void reset() override {
-    old_level_.set_none();
-    LatLongActuator::reset();
+    VehicleStateModel::reset();
     task_control_->reset();
+  }
+
+  cloe::Json to_json() const override {
+    return dynamic_cast<const cloe::VehicleStateModel&>(*this);
+  }
+
+ private:
+  void add_dyn_object_state() {
+    auto ego_state = this->vehicle_state();
+    assert(ego_state);
+    DynObjectState os;
+    assert(static_cast<uint64_t>(ego_state->id) == vehicle_id_);
+    os.base_id = ego_state->id;
+    os.base_type = cloe_vtd_obj_class_map.at(ego_state->classification);
+    os.base_name = vehicle_name_;
+    os.base_geo = rdb_geometry_from_object(ego_state.get());
+    os.base_pos = rdb_coord_from_object(ego_state.get());
+    os.ext_speed = rdb_coord_from_vector3d(ego_state->velocity, ego_state->angular_velocity);
+    os.ext_accel = rdb_coord_pos_from_vector3d(ego_state->acceleration);
+    // Add new ego state to task control message.
+    task_control_->add_dyn_object_state(os);
   }
 
  private:
   std::shared_ptr<TaskControl> task_control_;
   uint64_t vehicle_id_;
-  cloe::utility::ActuationLevel old_level_;
+  std::string vehicle_name_;
 };
 
 }  // namespace vtd

--- a/optional/vtd/src/osi_omni_sensor.cpp
+++ b/optional/vtd/src/osi_omni_sensor.cpp
@@ -627,8 +627,8 @@ void OsiOmniSensor::from_osi_boundary_points(const osi3::LaneBoundary& osi_lb,
     const auto& osi_pt = osi_lb.boundary_line(i);
     Eigen::Vector3d position = osi_vector3d_xyz_to_vector3d(osi_pt.position());
     // Transform points from the inertial into the sensor reference frame.
-    cloe::utility::transform_to_child_frame(osi_ego_pose_, &position);
-    cloe::utility::transform_to_child_frame(osi_sensor_pose_, &position);
+    cloe::utility::transform_point_to_child_frame(osi_ego_pose_, &position);
+    cloe::utility::transform_point_to_child_frame(osi_sensor_pose_, &position);
     lb.points.push_back(position);
   }
   // Compute clothoid segment. TODO(tobias): implement curved segments.

--- a/optional/vtd/src/osi_utils.cpp
+++ b/optional/vtd/src/osi_utils.cpp
@@ -115,7 +115,7 @@ void osi_transform_base_moving(const osi3::BaseMoving& base_ref, osi3::BaseMovin
 
   // Transform base.position/orientation/velocity/acceleration/orientation_rate:
   Eigen::Vector3d pos_ref_frame = pose.translation();
-  cloe::utility::transform_to_child_frame(pose_ref, &pos_ref_frame);
+  cloe::utility::transform_point_to_child_frame(pose_ref, &pos_ref_frame);
   pose.translation() = pos_ref_frame;          // location in reference frame
   pose.rotate(pose_ref.rotation().inverse());  // orientation in reference frame
   // Write new pose to base.

--- a/optional/vtd/src/task_control.hpp
+++ b/optional/vtd/src/task_control.hpp
@@ -31,7 +31,8 @@
   #include <VtdToolkit/RDBHandler.hh>
 #endif  
 
-#include <cloe/core.hpp>  // for Json
+#include <cloe/component/object.hpp>  // for Object
+#include <cloe/core.hpp>              // for Json
 
 #include "omni_sensor_component.hpp"  // for VtdOmniSensor
 #include "rdb_codec.hpp"              // for RdbCodec
@@ -76,6 +77,97 @@ struct DriverControl {
     };
   }
 };
+
+struct DynObjectState {
+  /// Object id.
+  uint32_t base_id{0};
+
+  /// Object category (player, sensor, ...).
+  uint8_t base_category{RDB_OBJECT_CATEGORY_PLAYER};
+
+  /// Object type (car, truck, ...).
+  uint8_t base_type{RDB_OBJECT_TYPE_NONE};
+
+  /// Visibility mask (e.g. visible for traffic and visible for data recorder).
+  uint16_t base_vis_mask{RDB_OBJECT_VIS_FLAG_TRAFFIC | RDB_OBJECT_VIS_FLAG_RECORDER};
+
+  /// Player name.
+  std::string base_name;
+
+  /// Object dimension and offset to cog.
+  RDB_GEOMETRY_t base_geo;
+
+  /// Object position and orientation.
+  RDB_COORD_t base_pos;
+
+  /// Object velocity and angular velocity.
+  RDB_COORD_t ext_speed;
+
+  /// Object acceleration and angular acceleration.
+  RDB_COORD_t ext_accel;
+
+  friend void to_json(cloe::Json& j, const DynObjectState& os) {
+    j = cloe::Json{
+        {"base_id", os.base_id},     {"base_category", os.base_category},
+        {"base_type", os.base_type}, {"base_vis_mask", os.base_vis_mask},
+        {"base_name", os.base_name},
+    };
+  }
+};
+
+/**
+ * Map to convert from Cloe to VTD object classification.
+ */
+const std::map<cloe::Object::Class, uint8_t> cloe_vtd_obj_class_map = {
+    {cloe::Object::Class::Car, RDB_OBJECT_TYPE_PLAYER_CAR},
+    {cloe::Object::Class::Truck, RDB_OBJECT_TYPE_PLAYER_TRUCK},
+    {cloe::Object::Class::Motorbike, RDB_OBJECT_TYPE_PLAYER_MOTORBIKE},
+    {cloe::Object::Class::Trailer, RDB_OBJECT_TYPE_PLAYER_TRAILER},
+};
+
+/**
+ * Convert object geometry VTD geometry.
+ */
+RDB_GEOMETRY_t rdb_geometry_from_object(const cloe::Object& obj) {
+  RDB_GEOMETRY_t geo;
+  geo.dimX = obj.dimensions.x();
+  geo.dimY = obj.dimensions.y();
+  geo.dimZ = obj.dimensions.z();
+  geo.offX = obj.cog_offset.x();
+  geo.offY = obj.cog_offset.y();
+  geo.offZ = obj.cog_offset.z();
+  return geo;
+}
+
+RDB_COORD_t rdb_coord_from_vector3d(const Eigen::Vector3d& position,
+                                    const Eigen::Vector3d& angle_rph) {
+  RDB_COORD_t coord;
+  coord.x = position.x();
+  coord.y = position.y();
+  coord.z = position.z();
+  coord.r = angle_rph.x();
+  coord.p = angle_rph.y();
+  coord.h = angle_rph.z();
+  coord.flags = RDB_COORD_FLAG_POINT_VALID | RDB_COORD_FLAG_ANGLES_VALID;
+  coord.type = RDB_COORD_TYPE_INERTIAL;
+  return coord;
+}
+
+RDB_COORD_t rdb_coord_from_object(const cloe::Object& obj) {
+  Eigen::Vector3d hpr = obj.pose.rotation().matrix().eulerAngles(2, 1, 0);
+  return rdb_coord_from_vector3d(obj.pose.translation(),
+                                 Eigen::Vector3d(hpr.z(), hpr.y(), hpr.x()));
+}
+
+RDB_COORD_t rdb_coord_pos_from_vector3d(const Eigen::Vector3d& position) {
+  RDB_COORD_t coord;
+  coord.x = position.x();
+  coord.y = position.y();
+  coord.z = position.z();
+  coord.flags = RDB_COORD_FLAG_POINT_VALID;
+  coord.type = RDB_COORD_TYPE_INERTIAL;
+  return coord;
+}
 
 /**
  * TaskControl contains the connection to the VTD task control server.
@@ -170,6 +262,29 @@ class TaskControl : public VtdOmniSensor {
     driverCtrl->steeringTgt = dc.target_steering;
     driverCtrl->flags = dc.driver_flags;
     driverCtrl->validityFlags = dc.validity_flags;
+  }
+
+  void add_dyn_object_state(const DynObjectState& os) {
+    // TODO(tobias): From the implementation of `add_driver_control`, it seems
+    // that the actual sim time and frame no. are not needed..
+    handler_.addPackage(0.0, 0, RDB_PKG_ID_START_OF_FRAME);
+    RDB_OBJECT_STATE_t* objState = reinterpret_cast<RDB_OBJECT_STATE_t*>(
+        handler_.addPackage(0.0, 0, RDB_PKG_ID_OBJECT_STATE, /*noElements=*/1,
+                            /*extended=*/true));
+    if (objState == nullptr) {
+      vtd_logger()->error("TaskControl: cannot add RDB_OBJECT_STATE package");
+      return;
+    }
+    objState->base.id = os.base_id;
+    objState->base.category = os.base_category;
+    objState->base.type = os.base_type;
+    objState->base.visMask = os.base_vis_mask;
+    std::strcpy(objState->base.name, os.base_name.c_str());
+    objState->base.geo = os.base_geo;
+    objState->base.pos = os.base_pos;
+    objState->ext.speed = os.ext_speed;
+    objState->ext.accel = os.ext_accel;
+    handler_.addPackage(0.0, 0, RDB_PKG_ID_END_OF_FRAME);
   }
 
   /**

--- a/optional/vtd/src/task_control.hpp
+++ b/optional/vtd/src/task_control.hpp
@@ -123,12 +123,35 @@ class TaskControl : public VtdOmniSensor {
 
   using VtdOmniSensor::process;
   void process(RDB_DRIVER_CTRL_t* driver_ctrl) override {
-    steering_wheel_speed_[driver_ctrl->playerId] = driver_ctrl->steeringSpeed;
+    // Steering speed at the front wheels [rad/s].
+    if (driver_ctrl->validityFlags & RDB_DRIVER_INPUT_VALIDITY_STEERING_SPEED) {
+      steering_wheel_speed_[driver_ctrl->playerId] = driver_ctrl->steeringSpeed;
+    } else {
+      vtd_logger()->warn("{}: steeringSpeed missing in RDB_DRIVER_CTRL_t", this->get_name());
+      steering_wheel_speed_[driver_ctrl->playerId] = 0.0;
+    }
+
+    // Longitudinal acceleration request [m/s2].
+    if (driver_ctrl->validityFlags & RDB_DRIVER_INPUT_VALIDITY_TGT_ACCEL) {
+      driver_request_accel_[driver_ctrl->playerId] = driver_ctrl->accelTgt;
+    } else {
+      vtd_logger()->warn("{}: accelTgt missing in RDB_DRIVER_CTRL_t", this->get_name());
+      driver_request_accel_[driver_ctrl->playerId] = 0.0;
+    }
+    // Steering request (angle at wheels) [rad].
+    if (driver_ctrl->validityFlags & RDB_DRIVER_INPUT_VALIDITY_TGT_STEERING) {
+      driver_request_steering_angle_[driver_ctrl->playerId] = driver_ctrl->steeringTgt;
+    } else {
+      vtd_logger()->warn("{}: steeringTgt missing in RDB_DRIVER_CTRL_t", this->get_name());
+      driver_request_steering_angle_[driver_ctrl->playerId] = 0.0;
+    }
   }
 
   void reset() override {
     VtdOmniSensor::reset();
     steering_wheel_speed_.clear();
+    driver_request_accel_.clear();
+    driver_request_steering_angle_.clear();
   }
 
   /**
@@ -186,9 +209,35 @@ class TaskControl : public VtdOmniSensor {
   }
 
   /**
-   * Get steering wheel speed of vehicle with given id.
+   * Get steering speed at front wheels of vehicle with given id [rad/s].
    */
   double get_steering_wheel_speed(uint64_t id) const { return steering_wheel_speed_.at(id); }
+
+  /**
+   * Get driver-requested longitudinal acceleration of vehicle with given id [m/s2].
+   */
+  double get_driver_request_acceleration(uint64_t id) const { return driver_request_accel_.at(id); }
+
+  /**
+   * Check if driver-requested longitudinal acceleration has been set.
+   */
+  bool has_driver_request_acceleration(uint64_t id) {
+    return driver_request_accel_.find(id) != driver_request_accel_.end();
+  }
+
+  /**
+   * Get driver-requested steering angle (at wheels) of vehicle with given id [rad].
+   */
+  double get_driver_request_steering_angle(uint64_t id) const {
+    return driver_request_steering_angle_.at(id);
+  }
+
+  /**
+   * Check if driver-requested steering_angle has been set.
+   */
+  bool has_driver_request_steering_angle(uint64_t id) {
+    return driver_request_steering_angle_.find(id) != driver_request_steering_angle_.end();
+  }
 
   friend void to_json(cloe::Json& j, const TaskControl& tc) {
     j = cloe::Json{{"rdb_connection", tc.rdb_}};
@@ -198,6 +247,8 @@ class TaskControl : public VtdOmniSensor {
   /// RDBHandler helps us conveniently construct RDB messages.
   Framework::RDBHandler handler_;
   std::map<int, double> steering_wheel_speed_;
+  std::map<int, double> driver_request_accel_;
+  std::map<int, double> driver_request_steering_angle_;
 };
 
 }  // namespace vtd

--- a/optional/vtd/src/vtd_binding.cpp
+++ b/optional/vtd/src/vtd_binding.cpp
@@ -414,7 +414,7 @@ class VtdBinding : public cloe::Simulator {
 
     // Send items to TaskControl:
     for (auto v : vehicles_) {
-      v->vtd_step_actuator(*scp_client_, config_.label_vehicle);
+      v->vtd_step_vehicle_control(sync, *scp_client_, config_.label_vehicle);
     }
 
     // Trigger VTD to simulation the next step

--- a/optional/vtd/src/vtd_binding.cpp
+++ b/optional/vtd/src/vtd_binding.cpp
@@ -393,11 +393,6 @@ class VtdBinding : public cloe::Simulator {
       return sync.time() - sync.step_width();
     }
 
-    // Send items to TaskControl:
-    for (auto v : vehicles_) {
-      v->vtd_step_actuator(*scp_client_, config_.label_vehicle);
-    }
-
     // Process task control messages
     {
       timer::DurationTimer<timer::Milliseconds> t([this](timer::Milliseconds d) {
@@ -415,6 +410,11 @@ class VtdBinding : public cloe::Simulator {
       for (auto v : vehicles_) {
         sensor_time = v->vtd_step_sensors(sync);
       }
+    }
+
+    // Send items to TaskControl:
+    for (auto v : vehicles_) {
+      v->vtd_step_actuator(*scp_client_, config_.label_vehicle);
     }
 
     // Trigger VTD to simulation the next step

--- a/optional/vtd/src/vtd_data_conversion_test.cpp
+++ b/optional/vtd/src/vtd_data_conversion_test.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Robert Bosch GmbH
+
+ */
+/**
+ * \file vtd_data_conversion_test.cpp
+ * \see  omni_sensor_component.hpp
+ * \see  task_control.hpp
+ */
+
+#include <cmath>  // for M_PI
+
+#include <gtest/gtest.h>              // for TEST, ASSERT_TRUE
+#include <cloe/component/object.hpp>  // for Object
+
+#include "omni_sensor_component.hpp"
+#include "task_control.hpp"
+
+RDB_COORD_t get_test_rdb_coord() {
+  RDB_COORD_t c;
+  c.x = 1.0;
+  c.y = 2.0;
+  c.z = 3.0;
+  c.h = 0.1 * M_PI;
+  c.p = 0.2 * M_PI;
+  c.r = 0.3 * M_PI;
+  c.flags = RDB_COORD_FLAG_POINT_VALID | RDB_COORD_FLAG_ANGLES_VALID;
+  return c;
+}
+
+void assert_rdb_coord_eq(const RDB_COORD_t& c1, const RDB_COORD_t& c2) {
+  ASSERT_DOUBLE_EQ(c1.x, c2.x);
+  ASSERT_DOUBLE_EQ(c1.y, c2.y);
+  ASSERT_DOUBLE_EQ(c1.z, c2.z);
+  if (c2.flags & RDB_COORD_FLAG_ANGLES_VALID) {
+    ASSERT_DOUBLE_EQ(c1.h, c2.h);
+    ASSERT_DOUBLE_EQ(c1.p, c2.p);
+    ASSERT_DOUBLE_EQ(c1.r, c2.r);
+  }
+}
+
+TEST(vtd_data, rdb_coord) {
+  // Convert from VTD to Cloe data and back.
+  RDB_COORD_t coord = get_test_rdb_coord();
+  cloe::Object obj;
+  obj.pose = vtd::from_vtd_pose(coord);
+  RDB_COORD_t coord2 = vtd::rdb_coord_from_object(obj);
+  assert_rdb_coord_eq(coord, coord2);
+  coord2 = vtd::rdb_coord_pos_from_vector3d(obj.pose.translation());
+  assert_rdb_coord_eq(coord, coord2);
+}

--- a/optional/vtd/src/vtd_sensor_components.hpp
+++ b/optional/vtd/src/vtd_sensor_components.hpp
@@ -19,9 +19,10 @@
  * \file vtd_sensor_components.hpp
  */
 
-#include <cloe/component/ego_sensor.hpp>     // for EgoSensor
-#include <cloe/component/lane_sensor.hpp>    // for LaneBoundarySensor
-#include <cloe/component/object_sensor.hpp>  // for ObjectSensor
+#include <cloe/component/driver_request.hpp>  // for DriverRequest
+#include <cloe/component/ego_sensor.hpp>      // for EgoSensor
+#include <cloe/component/lane_sensor.hpp>     // for LaneBoundarySensor
+#include <cloe/component/object_sensor.hpp>   // for ObjectSensor
 
 #include "task_control.hpp"     // for TaskControl
 #include "vtd_sensor_data.hpp"  // for VtdSensorData
@@ -75,6 +76,42 @@ class VtdLaneBoundarySensor : public cloe::LaneBoundarySensor {
 
  private:
   std::shared_ptr<VtdSensorData> data_;
+  std::shared_ptr<TaskControl> task_control_;
+};
+
+class VtdDriverRequest : public cloe::DriverRequest {
+ public:
+  explicit VtdDriverRequest(uint64_t id, std::shared_ptr<TaskControl> task_control)
+      : DriverRequest("vtd/driver_request"), id_(id), task_control_{task_control} {}
+
+  virtual ~VtdDriverRequest() = default;
+
+  bool has_acceleration() const override {
+    return task_control_->has_driver_request_acceleration(id_);
+  }
+
+  boost::optional<double> acceleration() const override {
+    boost::optional<double> accel;
+    if (this->has_acceleration()) {
+      accel = task_control_->get_driver_request_acceleration(id_);
+    }
+    return accel;
+  }
+
+  bool has_steering_angle() const override {
+    return task_control_->has_driver_request_steering_angle(id_);
+  }
+
+  boost::optional<double> steering_angle() const override {
+    boost::optional<double> angle;
+    if (this->has_steering_angle()) {
+      angle = task_control_->get_driver_request_steering_angle(id_);
+    }
+    return angle;
+  }
+
+ private:
+  uint64_t id_;
   std::shared_ptr<TaskControl> task_control_;
 };
 

--- a/optional/vtd/tests/conanfile_with_vtd-2.2.0.py
+++ b/optional/vtd/tests/conanfile_with_vtd-2.2.0.py
@@ -33,6 +33,7 @@ class CloeTest(ConanFile):
         self.requires(f"cloe-plugin-basic/{self.version}@cloe/develop")
         self.requires(f"cloe-plugin-noisy-sensor/{self.version}@cloe/develop")
         self.requires(f"cloe-plugin-speedometer/{self.version}@cloe/develop")
+        self.requires(f"cloe-plugin-gndtruth-extractor/{self.version}@cloe/develop")
         self.requires(f"cloe-plugin-virtue/{self.version}@cloe/develop")
         self.requires(f"cloe-plugin-vtd/{self.version}@cloe/develop")
         self.requires("incbin/cci.20211107", override=True)
@@ -45,4 +46,3 @@ class CloeTest(ConanFile):
         self.requires("zlib/1.2.13", override=True)
         if self.options["cloe-engine"].server:
             self.requires("boost/[<1.70]", override=True)
-

--- a/optional/vtd/tests/conanfile_with_vtd-2022.3.py
+++ b/optional/vtd/tests/conanfile_with_vtd-2022.3.py
@@ -33,15 +33,17 @@ class CloeTest(ConanFile):
         self.requires(f"cloe-plugin-basic/{self.version}@cloe/develop")
         self.requires(f"cloe-plugin-noisy-sensor/{self.version}@cloe/develop")
         self.requires(f"cloe-plugin-speedometer/{self.version}@cloe/develop")
+        self.requires(f"cloe-plugin-gndtruth-extractor/{self.version}@cloe/develop")
         self.requires(f"cloe-plugin-virtue/{self.version}@cloe/develop")
-        self.requires("incbin/cci.20211107", override=True)
         self.requires(f"cloe-plugin-vtd/{self.version}@cloe/develop")
-        self.requires("vtd-api/2022.3@cloe/stable", override=True)
+
         # Runtime requirements for VTD.
         self.requires("vtd/2022.3@cloe-restricted/stable")
 
         # Overrides:
         self.requires("zlib/1.2.13", override=True)
+        self.requires("incbin/cci.20211107", override=True)
+        self.requires("vtd-api/2022.3@cloe/stable", override=True)
 
         if self.options["cloe-engine"].server:
             self.requires("boost/[<1.70]", override=True)

--- a/optional/vtd/tests/test_vtd.bats
+++ b/optional/vtd/tests/test_vtd.bats
@@ -17,8 +17,7 @@ teardown() {
         skip "required simulator vtd not present"
     fi
     cloe-engine check test_vtd_smoketest.json
-    run cloe-engine run test_vtd_smoketest.json
-    test $status -eq $CLOE_EXIT_STOPPED
+    cloe-engine run test_vtd_smoketest.json
 }
 
 @test "$(testname "Expect check/run success" "test_vtd_scp_action.json" "3d1ec074-8f64-460c-8d2f-57ffc30d793c")" {
@@ -26,7 +25,8 @@ teardown() {
         skip "required simulator vtd not present"
     fi
     cloe-engine check test_vtd_scp_action.json
-    cloe-engine run test_vtd_scp_action.json
+    run cloe-engine run test_vtd_scp_action.json
+    test $status -eq $CLOE_EXIT_STOPPED
 }
 
 @test "$(testname "Expect check/run success" "test_vtd_api_recording.json" "71eaf779-2aa7-492b-83b5-27504ae92f9e")" {

--- a/plugins/basic/src/basic.hpp
+++ b/plugins/basic/src/basic.hpp
@@ -150,6 +150,7 @@ struct BasicConfiguration : public Confable {
   AccConfiguration acc;
   AebConfiguration aeb;
   LkaConfiguration lka;
+  std::string driver_request;
 
   void to_json(Json& j) const override {
     j = Json{
@@ -160,11 +161,14 @@ struct BasicConfiguration : public Confable {
   }
 
   CONFABLE_SCHEMA(BasicConfiguration) {
+    // clang-format off
     return Schema{
-        {"acc", Schema(&acc, "ACC configuration")},
-        {"aeb", Schema(&aeb, "AEB configuration")},
-        {"lka", Schema(&lka, "LKA configuration")},
+        {"acc",            Schema(&acc, "ACC configuration")},
+        {"aeb",            Schema(&aeb, "AEB configuration")},
+        {"lka",            Schema(&lka, "LKA configuration")},
+        {"driver_request", Schema(&driver_request, "component providing driver request")},
     };
+    // clang-format on
   }
 };
 


### PR DESCRIPTION
This PR addresses the findings of #66 by adding
* a new component `VehicleStateModel`
* a new interface `VtdVehicleControl` that covers both the `DriverControl` (set by `LatLongActuator`) and the `DynObjectState` (set by `VehicleStateModel`) messages
* a new component `DriverRequest` to give controllers access to driver model information from the simulator
* a simple arbitration logic to the basic controller functions.