### PR TITLE
ci: Fix test execution when triggered as a service

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -16,7 +16,15 @@ DOCKER_CONTEXT := ${PROJECT_ROOT}
 
 DOCKER_USER_ARGS +=
 DOCKER_BUILD_ARGS += --build-arg PROJECT_VERSION=${PROJECT_VERSION}
-DOCKER_RUN_ARGS += -it --rm
+# Detect if this executed in an interactive shell or by some service like a cron job or Jenkins where
+# commands are executed as non-TTY :
+DOCKER_RUN_ARGS += \
+  $(shell \
+		if [ -t 0 ]; then \
+			echo "-t"; \
+		fi \
+)
+DOCKER_RUN_ARGS += -i --rm
 
 ifndef (${https_proxy},)
 	DOCKER_NETWORK := host


### PR DESCRIPTION
Jenkins executes its jobs not in a TTY, hence we need to support this use case. How to simulate this change in a non Jenkins context (no-tty):

ssh -T localhost "cd $PWD ; make -f Makefile.docker test-ubuntu-18.04"

Where your current working directory must be where the Makefile.docker is located or instead of using $PWD just provide the absolute path of the Makefile.