### PR TITLE
oak: add boost full_package_mode to oak

### DIFF
--- a/oak/conanfile.py
+++ b/oak/conanfile.py
@@ -76,5 +76,6 @@ class CloeOak(ConanFile):
             self.cpp_info.libs = ["cloe-oak"]
 
     def package_id(self):
+        self.info.requires["boost"].full_package_mode()
         del self.info.options.test
         del self.info.options.pedantic


### PR DESCRIPTION
force rebuild of oak when a new boost version is required