### PR TITLE
Improve performance of Fable and extend String schema

### DIFF
--- a/fable/CMakeLists.txt
+++ b/fable/CMakeLists.txt
@@ -77,6 +77,7 @@ if(BUILD_TESTING)
         src/fable/schema/ignore_test.cpp
         src/fable/schema/number_test.cpp
         src/fable/schema/optional_test.cpp
+        src/fable/schema/string_test.cpp
         src/fable/schema/struct_test.cpp
         src/fable/schema_test.cpp
     )

--- a/fable/CMakeLists.txt
+++ b/fable/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(${target}
     src/fable/conf.cpp
     src/fable/json.cpp
     src/fable/schema.cpp
+    src/fable/schema/boolean.cpp
     src/fable/schema/number.cpp
     src/fable/schema/struct.cpp
     src/fable/schema/string.cpp

--- a/fable/CMakeLists.txt
+++ b/fable/CMakeLists.txt
@@ -19,6 +19,7 @@ file(GLOB ${target}_PUBLIC_HEADERS "include/**/*.hpp")
 add_library(${target}
     # find src -type f -name "*.cpp" \! -name "*_test.cpp"
     src/fable/conf.cpp
+    src/fable/confable.cpp
     src/fable/json.cpp
     src/fable/schema.cpp
     src/fable/schema/boolean.cpp

--- a/fable/CMakeLists.txt
+++ b/fable/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(${target}
     src/fable/conf.cpp
     src/fable/json.cpp
     src/fable/schema.cpp
+    src/fable/schema/number.cpp
     src/fable/schema/struct.cpp
     src/fable/schema/string.cpp
     src/fable/schema/variant.cpp

--- a/fable/examples/contacts/Makefile
+++ b/fable/examples/contacts/Makefile
@@ -7,22 +7,19 @@ BUILD_DIR := build
 # The build type must be synchronized between Conan (host build type)
 # and CMake, otherwise you will get strange and unhelpful errors.
 BUILD_TYPE := Release
+CMAKE_BUILD_TYPE := $(shell echo ${BUILD_TYPE} | tr '[:upper:]' '[:lower:]')
 
 # This is the output that Conan generates when using
 # `CMakeToolchain` generator AND the `cmake_layout` layout.
-TOOLCHAIN_FILE := ${BUILD_DIR}/generators/conan_toolchain.cmake
+TOOLCHAIN_FILE := ${BUILD_DIR}/${BUILD_TYPE}/generators/conan_toolchain.cmake
 
 .PHONY: all clean
 all: ${TOOLCHAIN_FILE}
-	cmake --build ${BUILD_DIR}
+	cmake --build --preset=${CMAKE_BUILD_TYPE}
 
 ${TOOLCHAIN_FILE}:
 	conan install . --build=missing --install-folder=${BUILD_DIR} -s:h build_type=${BUILD_TYPE}
-	cmake -B ${BUILD_DIR} -S . \
-		-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
-		-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-		-DCMAKE_EXPORT_COMPILE_COMMANDS=1
-	cmake --build ${BUILD_DIR}
+	cmake --preset=${CMAKE_BUILD_TYPE} -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 
 clean:
 	-rm -r ${BUILD_DIR}

--- a/fable/examples/simple_config/Makefile
+++ b/fable/examples/simple_config/Makefile
@@ -7,6 +7,7 @@ BUILD_DIR := build
 # The build type must be synchronized between Conan (host build type)
 # and CMake, otherwise you will get strange and unhelpful errors.
 BUILD_TYPE := Release
+CMAKE_BUILD_TYPE := $(shell echo ${BUILD_TYPE} | tr '[:upper:]' '[:lower:]')
 
 # This is the output that Conan generates when using
 # `CMakeToolchain` generator AND the `cmake_layout` layout.
@@ -14,15 +15,11 @@ TOOLCHAIN_FILE := ${BUILD_DIR}/generators/conan_toolchain.cmake
 
 .PHONY: all clean
 all: ${TOOLCHAIN_FILE}
-	cmake --build ${BUILD_DIR}
+	cmake --build --preset=${CMAKE_BUILD_TYPE}
 
 ${TOOLCHAIN_FILE}:
 	conan install . --build=missing --install-folder=${BUILD_DIR} -s:h build_type=${BUILD_TYPE}
-	cmake -B ${BUILD_DIR} -S . \
-		-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
-		-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-		-DCMAKE_EXPORT_COMPILE_COMMANDS=1
-	cmake --build ${BUILD_DIR}
+	cmake --preset=${CMAKE_BUILD_TYPE} -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 
 clean:
 	-rm -r ${BUILD_DIR}

--- a/fable/examples/simple_config/src/main.cpp
+++ b/fable/examples/simple_config/src/main.cpp
@@ -24,6 +24,7 @@
 
 #include <fable/confable.hpp>  // for fable::{Conf, Confable, Schema, ...}
 #include <fable/utility.hpp>   // for fable::read_conf
+#include <fable/schema.hpp>    // for Schema
 
 // A nested configuration structure
 struct NestedConfig : public fable::Confable {

--- a/fable/include/fable/confable.hpp
+++ b/fable/include/fable/confable.hpp
@@ -27,9 +27,8 @@
 
 #include <memory>  // for unique_ptr<>
 
-#include <fable/conf.hpp>    // for Conf
 #include <fable/json.hpp>    // for Json
-#include <fable/schema.hpp>  // for Schema
+#include <fable/conf.hpp>    // for Conf
 
 #define CONFABLE_FRIENDS(xType)                                           \
   using ::fable::Confable::to_json;                                       \
@@ -42,34 +41,25 @@
 
 namespace fable {
 
+class Schema;
+
 class Confable {
  public:
-  Confable() noexcept = default;
+  Confable() noexcept;
+  Confable(const Confable&) noexcept;
+  Confable(Confable&&) noexcept;
 
-  Confable(const Confable&) noexcept : schema_(nullptr) {}
-  Confable(Confable&&) noexcept : schema_(nullptr) {}
+  Confable& operator=(const Confable& other) noexcept;
+  Confable& operator=(Confable&& other) noexcept;
 
-  Confable& operator=(const Confable& other) noexcept {
-    if (this != &other) {
-      schema_.reset();
-    }
-    return *this;
-  }
-  Confable& operator=(Confable&& other) noexcept {
-    if (this != &other) {
-      schema_.reset();
-    }
-    return *this;
-  }
-
-  virtual ~Confable() noexcept = default;
+  virtual ~Confable() noexcept;
 
   /**
    * Reset the internal schema cache.
    *
    * This causes schema_impl to be called next time the schema is requested.
    */
-  virtual void reset_schema() { schema_.reset(); }
+  virtual void reset_schema();
 
   /**
    * Return the object schema for deserialization.
@@ -77,12 +67,7 @@ class Confable {
    * This method uses `schema_impl` under the hood, which the object should
    * implement.
    */
-  Schema& schema() {
-    if (!schema_) {
-      schema_ = std::make_unique<Schema>(schema_impl());
-    }
-    return *schema_.get();
-  }
+  Schema& schema();
 
   /**
    * Return the object schema for description and validation.
@@ -90,7 +75,7 @@ class Confable {
    * This method uses `schema_impl` under the hood, which the object should
    * implement.
    */
-  const Schema& schema() const { return const_cast<Confable*>(this)->schema(); }
+  const Schema& schema() const;
 
   /**
    * Validate a Conf without applying it.
@@ -102,7 +87,7 @@ class Confable {
    * This methodshould NOT call from_conf without also overriding from_conf
    * to prevent infinite recursion.
    */
-  virtual void validate(const Conf& c) const { schema().validate(c); }
+  virtual void validate(const Conf& c) const;
 
   /**
    * Deserialize a Confable from a Conf.
@@ -113,11 +98,7 @@ class Confable {
    *
    * and use the default implementation of this.
    */
-  virtual void from_conf(const Conf& c) {
-    validate(c);
-    schema().from_conf(c);
-    reset_schema();
-  }
+  virtual void from_conf(const Conf& c);
 
   /**
    * Serialize a Confable to Json.
@@ -125,16 +106,12 @@ class Confable {
    * Note: If you implement this type, make sure to either use CONFABLE_FRIENDS
    * or a using Confable::to_json statement in your derived type.
    */
-  virtual void to_json(Json& j) const { schema().to_json(j); }
+  virtual void to_json(Json& j) const;
 
   /**
    * Serialize a Confable to Json.
    */
-  Json to_json() const {
-    Json j;
-    to_json(j);
-    return j;
-  }
+  Json to_json() const;
 
  protected:
   /**
@@ -144,10 +121,10 @@ class Confable {
    * object is created or moved, since Schema contains references to fields
    * that (should be) in the object.
    */
-  virtual Schema schema_impl() { return schema::Struct(); }
+  virtual Schema schema_impl();
 
  private:
-  mutable std::unique_ptr<Schema> schema_{nullptr};
+  mutable std::unique_ptr<Schema> schema_;
 };
 
 }  // namespace fable

--- a/fable/include/fable/schema/boolean.hpp
+++ b/fable/include/fable/schema/boolean.hpp
@@ -37,35 +37,17 @@ class Boolean : public Base<Boolean> {
  public:  // Types and Constructors
   using Type = bool;
 
-  Boolean(Type* ptr, std::string&& desc) : Base(JsonType::boolean, std::move(desc)), ptr_(ptr) {}
+  Boolean(Type* ptr, std::string&& desc);
 
  public:  // Overrides
-  Json json_schema() const override {
-    Json j{
-        {"type", "boolean"},
-    };
-    this->augment_schema(j);
-    return j;
-  }
-
-  void validate(const Conf& c) const override { this->validate_type(c); }
-
+  Json json_schema() const override;
+  void validate(const Conf& c) const override;
   using Interface::to_json;
-  void to_json(Json& j) const override {
-    assert(ptr_ != nullptr);
-    j = serialize(*ptr_);
-  }
-
-  void from_conf(const Conf& c) override {
-    assert(ptr_ != nullptr);
-    *ptr_ = deserialize(c);
-  }
-
-  Json serialize(const Type& x) const { return x; }
-
-  Type deserialize(const Conf& c) const { return c.get<Type>(); }
-
-  void reset_ptr() override { ptr_ = nullptr; }
+  void to_json(Json& j) const override;
+  void from_conf(const Conf& c) override;
+  Json serialize(const Type& x) const;
+  Type deserialize(const Conf& c) const;
+  void reset_ptr() override;
 
  private:
   Type* ptr_{nullptr};

--- a/fable/include/fable/schema/number.hpp
+++ b/fable/include/fable/schema/number.hpp
@@ -26,12 +26,9 @@
 #define FABLE_SCHEMA_NUMBER_HPP_
 
 #include <initializer_list>  // for initializer_list<>
-#include <limits>            // for numeric_limits<>
 #include <set>               // for set<>
 #include <string>            // for string
 #include <type_traits>       // for enable_if_t<>, is_arithmetic<>
-#include <utility>           // for move
-#include <vector>            // for vector<>
 
 #include <fable/schema/interface.hpp>  // for Base<>
 
@@ -45,13 +42,11 @@ class Number : public Base<Number<T>> {
  public:  // Types and Constructors
   using Type = T;
 
-  template <typename X = T,
-            std::enable_if_t<std::is_integral<X>::value && std::is_unsigned<X>::value, int> = 0>
+  template <typename X = T, std::enable_if_t<std::is_integral<X>::value && std::is_unsigned<X>::value, int> = 0>
   Number(Type* ptr, std::string&& desc)
       : Base<Number<T>>(JsonType::number_unsigned, std::move(desc)), ptr_(ptr) {}
 
-  template <typename X = T,
-            std::enable_if_t<std::is_integral<X>::value && std::is_signed<X>::value, int> = 0>
+  template <typename X = T, std::enable_if_t<std::is_integral<X>::value && std::is_signed<X>::value, int> = 0>
   Number(Type* ptr, std::string&& desc)
       : Base<Number<T>>(JsonType::number_integer, std::move(desc)), ptr_(ptr) {}
 
@@ -59,208 +54,45 @@ class Number : public Base<Number<T>> {
   Number(Type* ptr, std::string&& desc)
       : Base<Number<T>>(JsonType::number_float, std::move(desc)), ptr_(ptr) {}
 
+
  public:  // Special
   T minimum() const { return value_min_; }
   bool exclusive_minimum() const { return exclusive_min_; }
-  Number<T> minimum(T value) && {
-    value_min_ = value;
-    exclusive_min_ = false;
-    return std::move(*this);
-  }
-  Number<T> exclusive_minimum(T value) && {
-    value_min_ = value;
-    exclusive_min_ = true;
-    return std::move(*this);
-  }
+  Number<T> minimum(T value) &&;
+  Number<T> exclusive_minimum(T value) &&;
 
   T maximum() const { return value_max_; }
   bool exclusive_maximum() const { return exclusive_max_; }
-  Number<T> maximum(T value) && {
-    value_max_ = value;
-    exclusive_max_ = false;
-    return std::move(*this);
-  }
-  Number<T> exclusive_maximum(T value) && {
-    value_max_ = value;
-    exclusive_max_ = true;
-    return std::move(*this);
-  }
+  Number<T> maximum(T value) &&;
+  Number<T> exclusive_maximum(T value) &&;
 
-  std::pair<T, T> bounds() const { return std::make_pair(value_min_, value_max_); }
-  Number<T> bounds(T min, T max) && {
-    exclusive_min_ = false;
-    value_min_ = min;
-    exclusive_max_ = false;
-    value_max_ = max;
-    return std::move(*this);
-  }
-  Number<T> bounds_with(T min, T max, std::initializer_list<T> whitelisted) {
-    exclusive_min_ = false;
-    value_min_ = min;
-    exclusive_max_ = false;
-    value_max_ = max;
-    for (auto x : whitelisted) {
-      insert_whitelist(x);
-    }
-    return std::move(*this);
-  }
+  std::pair<T, T> bounds() const;
+  Number<T> bounds(T min, T max) &&;
+  Number<T> bounds_with(T min, T max, std::initializer_list<T> whitelisted) &&;
 
   const std::set<T>& whitelist() const { return whitelist_; }
-  Number<T> whitelist(T x) && {
-    insert_whitelist(x);
-    return std::move(*this);
-  }
-  Number<T> whitelist(std::initializer_list<T> xs) && {
-    for (auto x : xs) {
-      insert_whitelist(x);
-    }
-    return std::move(*this);
-  }
-  void insert_whitelist(T x) {
-    if (std::is_floating_point<T>::value) {
-      throw std::logic_error("cannot whitelist floating-point numbers");
-    }
-    if (blacklist_.count(x)) {
-      throw std::logic_error("cannot add blacklisted value to whitelist: " + std::to_string(x));
-    }
-    whitelist_.insert(x);
-  }
+  Number<T> whitelist(T x) &&;
+  Number<T> whitelist(std::initializer_list<T> xs) &&;
+  void insert_whitelist(T x);
 
   const std::set<T>& blacklist() const { return blacklist_; }
-  Number<T> blacklist(T x) && {
-    insert_blacklist(x);
-    return std::move(*this);
-  }
-  Number<T> blacklist(std::initializer_list<T> xs) && {
-    for (auto x : xs) {
-      insert_blacklist(x);
-    }
-    return std::move(*this);
-  }
-  void insert_blacklist(T x) {
-    if (std::is_floating_point<T>::value) {
-      throw std::logic_error("cannot blacklist floating-point numbers");
-    }
-    if (blacklist_.count(x)) {
-      throw std::logic_error("cannot add whitelisted value to blacklist: " + std::to_string(x));
-    }
-    blacklist_.insert(x);
-  }
+  Number<T> blacklist(T x) &&;
+  Number<T> blacklist(std::initializer_list<T> xs) &&;
+  void insert_blacklist(T x);
 
  public:  // Overrides
-  Json json_schema() const override {
-    Json j{
-        {"type", this->type_string()},
-        {exclusive_min_ ? "exclusiveMinimum" : "minimum", value_min_},
-        {exclusive_max_ ? "exclusiveMaximum" : "maximum", value_max_},
-    };
-
-    if (!std::is_floating_point<T>::value) {
-      auto write_list = [&j](auto name, auto xlist) {
-        if (!xlist.empty()) {
-          std::vector<T> xs;
-          for (auto x : xlist) {
-            xs.emplace_back(x);
-          }
-          j[name] = xs;
-        }
-      };
-
-      write_list("whitelist", whitelist_);
-      write_list("blacklist", blacklist_);
-    }
-
-    this->augment_schema(j);
-    return j;
-  }
-
-  void validate(const Conf& c) const override {
-    switch (c->type()) {
-      case JsonType::number_unsigned: {
-        check_bounds<uint64_t>(c);
-        break;
-      }
-      case JsonType::number_integer: {
-        check_bounds<int64_t>(c);
-        break;
-      }
-      case JsonType::number_float: {
-        if (this->type() != JsonType::number_float) {
-          this->throw_wrong_type(c);
-        }
-        check_bounds<double>(c);
-        break;
-      }
-      default:
-        this->throw_wrong_type(c);
-    }
-  }
-
+  Json json_schema() const override;
+  void validate(const Conf& c) const override;
   using Interface::to_json;
-  void to_json(Json& j) const override {
-    assert(ptr_ != nullptr);
-    j = serialize(*ptr_);
-  }
-
-  void from_conf(const Conf& c) override {
-    assert(ptr_ != nullptr);
-    *ptr_ = deserialize(c);
-  }
-
-  Json serialize(const Type& x) const { return x; }
-
-  Type deserialize(const Conf& c) const { return c.get<Type>(); }
-
-  void reset_ptr() override { ptr_ = nullptr; }
+  void to_json(Json& j) const override;
+  void from_conf(const Conf& c) override;
+  Json serialize(const Type& x) const;
+  Type deserialize(const Conf& c) const;
+  void reset_ptr() override;
 
  private:
-  /**
-   * Check that the min and max bounds are held by c.
-   */
   template <typename B>
-  void check_bounds(const Conf& c) const {
-    auto v = c.get<B>();
-
-    // Check whitelist and blacklist first.
-    if (!std::is_floating_point<T>::value) {
-      if (whitelist_.count(v)) {
-        return;
-      }
-      if (blacklist_.count(v)) {
-        this->throw_error(c, "unexpected blacklisted value {}", v);
-      }
-    }
-
-    if (!std::numeric_limits<B>::is_signed && value_min_ < 0) {
-      // If B is unsigned and value_min_ is less than 0, there is no way
-      // that v cannot fulfill the minimum requirements. Trying to use the
-      // other branches will "underflow" the value_min_ which will invalidate
-      // any comparison.
-    } else if (exclusive_min_) {
-      if (v <= static_cast<B>(value_min_)) {
-        this->throw_error(c, "expected exclusive minimum of {}, got {}", value_min_, v);
-      }
-    } else {
-      if (v < static_cast<B>(value_min_)) {
-        this->throw_error(c, "expected minimum of {}, got {}", value_min_, v);
-      }
-    }
-
-    if (!std::numeric_limits<B>::is_signed && value_max_ < 0) {
-      // If B is unsigned, but our maximum value is somewhere below 0, then v
-      // will by definition always be out-of-bounds.
-      this->throw_error(c, "expected {}maximum of {}, got {}", (exclusive_max_ ? "exclusive " : ""),
-                        value_max_, v);
-    } else if (exclusive_max_) {
-      if (v >= static_cast<B>(value_max_)) {
-        this->throw_error(c, "expected exclusive maximum of {}, got {}", value_max_, v);
-      }
-    } else {
-      if (v > static_cast<B>(value_max_)) {
-        this->throw_error(c, "expected maximum of {}, got {}", value_max_, v);
-      }
-    }
-  }
+  void check_bounds(const Conf& c) const;
 
  private:
   bool exclusive_min_{false};

--- a/fable/include/fable/schema/number_impl.hpp
+++ b/fable/include/fable/schema/number_impl.hpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2020 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file fable/schema/number_impl.hpp
+ * \see  fable/schema.hpp
+ * \see  fable/schema_test.cpp
+ *
+ * You should only include this file if you need to use a type that is
+ * numeric and not one of the standard primitives.
+ */
+
+#pragma once
+#ifndef FABLE_SCHEMA_NUMBER_IMPL_HPP_
+#define FABLE_SCHEMA_NUMBER_IMPL_HPP_
+
+#include <initializer_list>  // for initializer_list<>
+#include <limits>            // for numeric_limits<>
+#include <set>               // for set<>
+#include <string>            // for string
+#include <type_traits>       // for enable_if_t<>, is_arithmetic<>
+#include <utility>           // for move
+#include <vector>            // for vector<>
+
+#include <fable/schema/number.hpp>  // for Number<>
+
+namespace fable {
+namespace schema {
+
+template <typename T>
+Number<T> Number<T>::minimum(T value) && {
+  value_min_ = value;
+  exclusive_min_ = false;
+  return std::move(*this);
+}
+
+template <typename T>
+Number<T> Number<T>::exclusive_minimum(T value) && {
+  value_min_ = value;
+  exclusive_min_ = true;
+  return std::move(*this);
+}
+
+template <typename T>
+Number<T> Number<T>::maximum(T value) && {
+  value_max_ = value;
+  exclusive_max_ = false;
+  return std::move(*this);
+}
+
+template <typename T>
+Number<T> Number<T>::exclusive_maximum(T value) && {
+  value_max_ = value;
+  exclusive_max_ = true;
+  return std::move(*this);
+}
+
+template <typename T>
+std::pair<T, T> Number<T>::bounds() const { return std::make_pair(value_min_, value_max_); }
+
+template <typename T>
+Number<T> Number<T>::bounds(T min, T max) && {
+  exclusive_min_ = false;
+  value_min_ = min;
+  exclusive_max_ = false;
+  value_max_ = max;
+  return std::move(*this);
+}
+
+template <typename T>
+Number<T> Number<T>::bounds_with(T min, T max, std::initializer_list<T> whitelisted) && {
+  exclusive_min_ = false;
+  value_min_ = min;
+  exclusive_max_ = false;
+  value_max_ = max;
+  for (auto x : whitelisted) {
+    insert_whitelist(x);
+  }
+  return std::move(*this);
+}
+
+template <typename T>
+Number<T> Number<T>::whitelist(T x) && {
+  insert_whitelist(x);
+  return std::move(*this);
+}
+
+template <typename T>
+Number<T> Number<T>::whitelist(std::initializer_list<T> xs) && {
+  for (auto x : xs) {
+    insert_whitelist(x);
+  }
+  return std::move(*this);
+}
+
+template <typename T>
+void Number<T>::insert_whitelist(T x) {
+  if (std::is_floating_point<T>::value) {
+    throw std::logic_error("cannot whitelist floating-point numbers");
+  }
+  if (blacklist_.count(x)) {
+    throw std::logic_error("cannot add blacklisted value to whitelist: " + std::to_string(x));
+  }
+  whitelist_.insert(x);
+}
+
+template <typename T>
+Number<T> Number<T>::blacklist(T x) && {
+  insert_blacklist(x);
+  return std::move(*this);
+}
+
+template <typename T>
+Number<T> Number<T>::blacklist(std::initializer_list<T> xs) && {
+  for (auto x : xs) {
+    insert_blacklist(x);
+  }
+  return std::move(*this);
+}
+
+template <typename T>
+void Number<T>::insert_blacklist(T x) {
+  if (std::is_floating_point<T>::value) {
+    throw std::logic_error("cannot blacklist floating-point numbers");
+  }
+  if (blacklist_.count(x)) {
+    throw std::logic_error("cannot add whitelisted value to blacklist: " + std::to_string(x));
+  }
+  blacklist_.insert(x);
+}
+
+template <typename T>
+Json Number<T>::json_schema() const {
+  Json j{
+      {"type", this->type_string()},
+      {exclusive_min_ ? "exclusiveMinimum" : "minimum", value_min_},
+      {exclusive_max_ ? "exclusiveMaximum" : "maximum", value_max_},
+  };
+
+  if (!std::is_floating_point<T>::value) {
+    auto write_list = [&j](auto name, auto xlist) {
+      if (!xlist.empty()) {
+        std::vector<T> xs;
+        for (auto x : xlist) {
+          xs.emplace_back(x);
+        }
+        j[name] = xs;
+      }
+    };
+
+    write_list("whitelist", whitelist_);
+    write_list("blacklist", blacklist_);
+  }
+
+  this->augment_schema(j);
+  return j;
+}
+
+template <typename T>
+void Number<T>::validate(const Conf& c) const {
+  switch (c->type()) {
+    case JsonType::number_unsigned: {
+      check_bounds<uint64_t>(c);
+      break;
+    }
+    case JsonType::number_integer: {
+      check_bounds<int64_t>(c);
+      break;
+    }
+    case JsonType::number_float: {
+      if (this->type() != JsonType::number_float) {
+        this->throw_wrong_type(c);
+      }
+      check_bounds<double>(c);
+      break;
+    }
+    default:
+      this->throw_wrong_type(c);
+  }
+}
+
+template <typename T>
+void Number<T>::to_json(Json& j) const {
+  assert(ptr_ != nullptr);
+  j = serialize(*ptr_);
+}
+
+template <typename T>
+void Number<T>::from_conf(const Conf& c) {
+  assert(ptr_ != nullptr);
+  *ptr_ = deserialize(c);
+}
+
+template <typename T>
+Json Number<T>::serialize(const T& x) const { return x; }
+
+template <typename T>
+T Number<T>::deserialize(const Conf& c) const { return c.get<T>(); }
+
+template <typename T>
+void Number<T>::reset_ptr() { ptr_ = nullptr; }
+
+/**
+ * Check that the min and max bounds are held by c.
+ */
+template <typename T>
+template <typename B>
+void Number<T>::check_bounds(const Conf& c) const {
+  auto v = c.get<B>();
+
+  // Check whitelist and blacklist first.
+  if (!std::is_floating_point<T>::value) {
+    if (whitelist_.count(v)) {
+      return;
+    }
+    if (blacklist_.count(v)) {
+      this->throw_error(c, "unexpected blacklisted value {}", v);
+    }
+  }
+
+  if (!std::numeric_limits<B>::is_signed && value_min_ < 0) {
+    // If B is unsigned and value_min_ is less than 0, there is no way
+    // that v cannot fulfill the minimum requirements. Trying to use the
+    // other branches will "underflow" the value_min_ which will invalidate
+    // any comparison.
+  } else if (exclusive_min_) {
+    if (v <= static_cast<B>(value_min_)) {
+      this->throw_error(c, "expected exclusive minimum of {}, got {}", value_min_, v);
+    }
+  } else {
+    if (v < static_cast<B>(value_min_)) {
+      this->throw_error(c, "expected minimum of {}, got {}", value_min_, v);
+    }
+  }
+
+  if (!std::numeric_limits<B>::is_signed && value_max_ < 0) {
+    // If B is unsigned, but our maximum value is somewhere below 0, then v
+    // will by definition always be out-of-bounds.
+    this->throw_error(c, "expected {}maximum of {}, got {}", (exclusive_max_ ? "exclusive " : ""),
+                      value_max_, v);
+  } else if (exclusive_max_) {
+    if (v >= static_cast<B>(value_max_)) {
+      this->throw_error(c, "expected exclusive maximum of {}, got {}", value_max_, v);
+    }
+  } else {
+    if (v > static_cast<B>(value_max_)) {
+      this->throw_error(c, "expected maximum of {}, got {}", value_max_, v);
+    }
+  }
+}
+
+}  // namespace schema
+}  // namespace fable
+
+#endif  // FABLE_SCHEMA_NUMBER_IMPL_HPP_

--- a/fable/include/fable/schema/string.hpp
+++ b/fable/include/fable/schema/string.hpp
@@ -18,6 +18,7 @@
 /**
  * \file fable/schema/string.hpp
  * \see  fable/schema/string.cpp
+ * \see  fable/schema/string_test.cpp
  * \see  fable/schema.hpp
  * \see  fable/schema_test.cpp
  */
@@ -29,6 +30,7 @@
 #include <limits>   // for numeric_limits<>
 #include <string>   // for string
 #include <utility>  // for move
+#include <vector>   // for vector<>
 
 #include <fable/schema/interface.hpp>  // for Base<>
 
@@ -213,6 +215,34 @@ class String : public Base<String> {
    */
   void set_environment(Environment* env);
 
+  /**
+   * Return the set of valid values for the string.
+   *
+   * \return valid values
+   */
+  const std::vector<std::string>& enum_of() const;
+
+  /**
+   * Set the valid values for the string.
+   *
+   * \note If a pattern is set, the string will need to validate
+   * against the pattern in addition to this list.
+   *
+   * \param init list of valid values
+   * \return *this, for chaining
+   */
+  String enum_of(std::vector<std::string>&& init);
+
+  /**
+   * Set the valid values for the string.
+   *
+   * \note If a pattern is set, the string will need to validate
+   * against the pattern in addition to this list.
+   *
+   * \param init list of valid values
+   */
+  void set_enum_of(std::vector<std::string>&& init);
+
  public:  // Overrides
   Json json_schema() const override;
   void validate(const Conf& c) const override;
@@ -228,6 +258,7 @@ class String : public Base<String> {
   size_t min_length_{0};
   size_t max_length_{std::numeric_limits<size_t>::max()};
   std::string pattern_{};
+  std::vector<std::string> enum_{};
   Environment* env_{nullptr};
   Type* ptr_{nullptr};
 };

--- a/fable/include/fable/utility/gtest.hpp
+++ b/fable/include/fable/utility/gtest.hpp
@@ -35,20 +35,50 @@
 
 namespace fable {
 
+/**
+ * Assert that both JSON values are identical.
+ *
+ * This function dumps both JSON with indentation so that failing
+ * tests can nicely format the diff between strings.
+ */
 inline void assert_eq(const Json& j, const Json& k) {
   ASSERT_EQ(std::string(j.dump(2)), std::string(k.dump(2)));
 }
 
+/**
+ * Assert that both JSON values are identical.
+ *
+ * The second parameter is parsed to JSON and then dumped.
+ *
+ * This function dumps both JSON with indentation so that failing
+ * tests can nicely format the diff between strings.
+ */
 inline void assert_eq(const Json& j, const char expect[]) {
   assert_eq(j, parse_json(expect));
 }
 
+/**
+ * Assert that both JSON values are NOT identical.
+ */
 inline void assert_ne(const Json& j, const Json& k) {
   ASSERT_NE(std::string(j.dump(2)), std::string(k.dump(2)));
 }
 
+/**
+ * Assert that both JSON values are NOT identical.
+ *
+ * The second parameter is parsed to JSON and then dumped.
+ */
 inline void assert_ne(const Json& j, const char expect[]) {
   assert_ne(j, parse_json(expect));
+}
+
+inline void assert_schema_eq(const Schema& s, const Json& expect) {
+  assert_eq(s.json_schema(), expect);
+}
+
+inline void assert_schema_eq(const Schema& s, const char expect[]) {
+  assert_eq(s.json_schema(), parse_json(expect));
 }
 
 inline void assert_schema_eq(const Confable& x, const Json& expect) {
@@ -59,32 +89,56 @@ inline void assert_schema_eq(const Confable& x, const char expect[]) {
   assert_eq(x.schema().json_schema(), parse_json(expect));
 }
 
-inline void assert_validate(const Confable& x, const Conf& input) {
+inline void assert_validate(const Schema& s, const Conf& input) {
   try {
-    x.schema().validate(input);
+    s.validate(input);
   } catch (SchemaError& e) {
     pretty_print(e, std::cerr);
     throw;
   };
 }
 
+inline void assert_validate(const Schema& s, const char json_input[]) {
+  assert_validate(s, Conf{parse_json(json_input)});
+}
+
+inline void assert_validate(const Confable& x, const Conf& input) {
+  assert_validate(x.schema(), input);
+}
+
 inline void assert_validate(const Confable& x, const char json_input[]) {
-  assert_validate(x, Conf{parse_json(json_input)});
+  assert_validate(x.schema(), Conf{parse_json(json_input)});
+}
+
+inline void assert_invalidate(const Schema& s, const Conf& input) {
+  ASSERT_THROW(s.validate(input), SchemaError);
+}
+
+inline void assert_invalidate(const Schema& s, const char json_input[]) {
+  ASSERT_THROW(s.validate(Conf{parse_json(json_input)}), SchemaError);
 }
 
 inline void assert_invalidate(const Confable& x, const Conf& input) {
-  ASSERT_THROW(x.schema().validate(input), SchemaError);
+  assert_invalidate(x.schema(), input);
 }
 
 inline void assert_invalidate(const Confable& x, const char json_input[]) {
   assert_invalidate(x, Conf{parse_json(json_input)});
 }
 
+/**
+ * Assert that the serialization is equal to the expected JSON.
+ */
 template <typename T>
 inline void assert_to_json(const T& x, const Json& expect) {
   assert_eq(x.to_json(), expect);
 }
 
+/**
+ * Assert that the serialization is equal to the expected JSON string.
+ *
+ * The string is parsed to Json, so that field order is not important.
+ */
 template <typename T>
 inline void assert_to_json(const T& x, const char json_expect[]) {
   assert_to_json(x, parse_json(json_expect));
@@ -110,12 +164,24 @@ inline void assert_from_conf(T& x, const char json_input[]) {
   assert_from_conf(x, Conf{parse_json(json_input)});
 }
 
+/**
+ * Assert that deserializing the input works and serializes to the same input.
+ *
+ * This asserts that the type supports the identity function. This does not need
+ * to hold for any type, but you may want it to hold for your type.
+ */
 template <typename T>
 inline void assert_from_eq_to(T& x, const Json& identity) {
   assert_from_conf(x, Conf{identity});
   assert_to_json(x, identity);
 }
 
+/**
+ * Assert that deserializing the input works and serializes to the same input.
+ *
+ * This asserts that the type supports the identity function. This does not need
+ * to hold for any type, but you may want it to hold for your type.
+ */
 template <typename T>
 inline void assert_from_eq_to(T& x, const char json_input[]) {
   assert_from_eq_to(x, parse_json(json_input));

--- a/fable/include/fable/utility/gtest.hpp
+++ b/fable/include/fable/utility/gtest.hpp
@@ -29,6 +29,7 @@
 
 #include <fable/conf.hpp>      // for Conf, Json
 #include <fable/confable.hpp>  // for Confable
+#include <fable/schema.hpp>    // for Schema
 #include <fable/error.hpp>     // for SchemaError
 #include <fable/utility.hpp>   // for pretty_print
 

--- a/fable/src/fable/confable.cpp
+++ b/fable/src/fable/confable.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file fable/confable.cpp
+ * \see  fable/confable.cpp
+ * \see  fable/schema.hpp
+ */
+
+#include <fable/confable.hpp>
+
+#include <fable/conf.hpp>    // for Conf
+#include <fable/schema.hpp>  // for Schema
+
+namespace fable {
+
+Confable::Confable() noexcept {};
+
+Confable::Confable(const Confable&) noexcept : schema_(nullptr) {}
+
+Confable::Confable(Confable&&) noexcept : schema_(nullptr) {}
+
+Confable& Confable::operator=(const Confable& other) noexcept {
+  if (this != &other) {
+    schema_.reset();
+  }
+  return *this;
+}
+
+Confable& Confable::operator=(Confable&& other) noexcept {
+  if (this != &other) {
+    schema_.reset();
+  }
+  return *this;
+}
+
+Confable::~Confable() noexcept {};
+
+void Confable::reset_schema() { schema_.reset(); }
+
+Schema& Confable::schema() {
+  if (!schema_) {
+    schema_ = std::make_unique<Schema>(schema_impl());
+  }
+  return *schema_.get();
+}
+
+const Schema& Confable::schema() const { return const_cast<Confable*>(this)->schema(); }
+
+void Confable::validate(const Conf& c) const { schema().validate(c); }
+
+void Confable::from_conf(const Conf& c) {
+  validate(c);
+  schema().from_conf(c);
+  reset_schema();
+}
+
+void Confable::to_json(Json& j) const { schema().to_json(j); }
+
+Json Confable::to_json() const {
+  Json j;
+  to_json(j);
+  return j;
+}
+
+Schema Confable::schema_impl() { return schema::Struct(); }
+
+}

--- a/fable/src/fable/schema/boolean.cpp
+++ b/fable/src/fable/schema/boolean.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file fable/schema/boolean.cpp
+ * \see  fable/schema/boolean.hpp
+ */
+
+#include <fable/schema/boolean.hpp>
+
+#include <string>   // for string
+#include <utility>  // for move
+
+namespace fable {
+namespace schema {
+
+Boolean::Boolean(Boolean::Type* ptr, std::string&& desc)
+  : Base(JsonType::boolean, std::move(desc)), ptr_(ptr) {}
+
+  Json Boolean::json_schema() const {
+    Json j{
+        {"type", "boolean"},
+    };
+    this->augment_schema(j);
+    return j;
+  }
+
+void Boolean::validate(const Conf& c) const { this->validate_type(c); }
+
+void Boolean::to_json(Json& j) const {
+  assert(ptr_ != nullptr);
+  j = serialize(*ptr_);
+}
+
+void Boolean::from_conf(const Conf& c) {
+  assert(ptr_ != nullptr);
+  *ptr_ = deserialize(c);
+}
+
+Json Boolean::serialize(const Type& x) const { return x; }
+
+Boolean::Type Boolean::deserialize(const Conf& c) const { return c.get<Type>(); }
+
+void Boolean::reset_ptr() { ptr_ = nullptr; }
+
+}  // namespace schema
+}  // namespace fable

--- a/fable/src/fable/schema/number.cpp
+++ b/fable/src/fable/schema/number.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file fable/schema/number_impl.cpp
+ * \see  fable/schema/number_impl.hpp
+ * \see  fable/schema/number.hpp
+ *
+ * This file provides the expected instantiations for the Number<T> schema.
+ * This should improve compilation time significantly.
+ *
+ * If the type you want to use is not here, you can simply include
+ * number_impl.hpp header.
+ */
+
+#include <fable/schema/number_impl.hpp>
+
+namespace fable {
+namespace schema {
+
+template class Number<char>;
+template class Number<unsigned char>;
+template class Number<short>;
+template class Number<unsigned short>;
+template class Number<int>;
+template class Number<unsigned int>;
+template class Number<long int>;
+template class Number<unsigned long int>;
+template class Number<long long int>;
+template class Number<unsigned long long int>;
+template class Number<float>;
+template class Number<double>;
+template class Number<long double>;
+
+}  // namespace schema
+}  // namespace fable

--- a/fable/src/fable/schema/string.cpp
+++ b/fable/src/fable/schema/string.cpp
@@ -31,6 +31,51 @@
 namespace fable {
 namespace schema {
 
+size_t String::min_length() const { return min_length_; }
+void String::set_min_length(size_t value) { min_length_ = value; }
+String String::min_length(size_t value) && {
+  min_length_ = value;
+  return std::move(*this);
+}
+
+String String::not_empty() && {
+  set_min_length(1);
+  return std::move(*this);
+}
+
+size_t String::max_length() const { return max_length_; }
+void String::set_max_length(size_t value) { max_length_ = value; }
+String String::max_length(size_t value) && {
+  max_length_ = value;
+  return std::move(*this);
+}
+
+const std::string& String::pattern() const { return pattern_; }
+void String::set_pattern(const std::string& value) { pattern_ = value; }
+String String::pattern(const std::string& value) && {
+  pattern_ = value;
+  return std::move(*this);
+}
+
+String String::c_identifier() && {
+  set_pattern(FABLE_REGEX_C_IDENTIFIER);
+  return std::move(*this);
+}
+
+bool String::interpolate() const { return interpolate_; }
+void String::set_interpolate(bool value) { interpolate_ = value; }
+String String::interpolate(bool value) && {
+  interpolate_ = value;
+  return std::move(*this);
+}
+
+Environment* String::environment() const { return env_; }
+void String::set_environment(Environment* env) { env_ = env; }
+String String::environment(Environment* env) && {
+  env_ = env;
+  return std::move(*this);
+}
+
 Json String::json_schema() const {
   Json j{
       {"type", "string"},
@@ -66,9 +111,23 @@ void String::validate(const Conf& c) const {
   }
 }  // namespace schema
 
+void String::reset_ptr() { ptr_ = nullptr; }
+
+Json String::serialize(const String::Type& x) const { return x; }
+
 String::Type String::deserialize(const Conf& c) const {
   auto s = c.get<Type>();
   return (interpolate_ ? interpolate_vars(s, env_) : s);
+}
+
+void String::to_json(Json& j) const {
+  assert(ptr_ != nullptr);
+  j = serialize(*ptr_);
+}
+
+void String::from_conf(const Conf& c) {
+  assert(ptr_ != nullptr);
+  *ptr_ = deserialize(c);
 }
 
 }  // namespace schema

--- a/fable/src/fable/schema/string_test.cpp
+++ b/fable/src/fable/schema/string_test.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * \file fable/schema/string_test.cpp
+ * \see  fable/schema/string.hpp
+ */
+
+#include <gtest/gtest.h>
+
+#include <fable/confable.hpp>       // for Confable
+#include <fable/environment.hpp>    // for Environment
+#include <fable/schema/string.hpp>  // for String, ...
+#include <fable/utility/gtest.hpp>  // for assert_to_json, ...
+
+#define TO_CONF(x) fable::Conf{fable::Json(x)}
+
+TEST(fable_schema_string, plain) {
+  std::string t;
+  auto s = fable::schema::make_schema(&t, "plain");
+
+  fable::assert_to_json(s, TO_CONF(""));
+  fable::assert_from_eq_to(s, TO_CONF("hello string"));
+  fable::assert_schema_eq(s, R"({
+    "type": "string",
+    "description": "plain"
+  })");
+}
+
+TEST(fable_schema_string, not_empty) {
+  std::string t;
+  auto s = fable::schema::make_schema(&t, "not empty").not_empty();
+
+  fable::assert_invalidate(s, TO_CONF(""));
+  fable::assert_from_eq_to(s, TO_CONF("not empty"));
+  fable::assert_schema_eq(s, R"({
+    "type": "string",
+    "description": "not empty",
+    "minLength": 1
+  })");
+}
+
+TEST(fable_schema_string, min_max_length) {
+  std::string t;
+  auto s = fable::schema::make_schema(&t, "min 4, max 8").min_length(4).max_length(8);
+
+  for (const auto& x : {"", "a", "asdfasdfx"}) {
+    fable::assert_invalidate(s, TO_CONF(x));
+  }
+  for (const auto& x : {"asdf", "xxxxxx", "abcdefgh"}) {
+    fable::assert_from_eq_to(s, TO_CONF(x));
+  }
+  fable::assert_schema_eq(s, R"({
+    "type": "string",
+    "description": "min 4, max 8",
+    "minLength": 4,
+    "maxLength": 8
+  })");
+}
+
+TEST(fable_schema_string, pattern) {
+  std::string t;
+  auto s = fable::schema::make_schema(&t, "c_identifier").c_identifier();
+
+  for (const auto& x : {"0_", "0", "not identifier", "", "a-b"}) {
+    fable::assert_invalidate(s, TO_CONF(x));
+  }
+  for (const auto& x : {"asdf", "_8", "_", "c_identier", "somethingElse"}) {
+    fable::assert_from_eq_to(s, TO_CONF(x));
+  }
+  fable::assert_schema_eq(s, R"({
+    "type": "string",
+    "description": "c_identifier",
+    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+  })");
+}
+
+TEST(fable_schema_string, interpolate) {
+  std::string t;
+  fable::Environment env{
+    {"TEST", "true"},
+    {"NAME", "world"}
+  };
+  auto s = fable::schema::make_schema(&t, "interpolate").interpolate(true).environment(&env);
+
+  EXPECT_ANY_THROW(assert_from_conf(s, TO_CONF("${}")));
+  EXPECT_ANY_THROW(assert_from_conf(s, TO_CONF("${__UNLIKELY}")));
+
+  fable::assert_from_conf(s, TO_CONF("${__UNLIKELY-default}"));
+  fable::assert_to_json(s, fable::Json("default"));
+  ASSERT_EQ(t, "default");
+
+  fable::assert_from_conf(s, TO_CONF("${TEST-false}"));
+  fable::assert_to_json(s, fable::Json("true"));
+  ASSERT_EQ(t, "true");
+
+  fable::assert_from_conf(s, TO_CONF("hello ${NAME}"));
+  fable::assert_to_json(s, fable::Json("hello world"));
+  ASSERT_EQ(t, "hello world");
+
+  fable::assert_schema_eq(s, R"({
+    "type": "string",
+    "description": "interpolate"
+  })");
+}
+
+TEST(fable_schema_string, enum) {
+  std::string t;
+  auto s = fable::schema::make_schema(&t, "enum").enum_of({"true", "false"});
+
+  for (const auto& x : {"", "asdf", "False"}) {
+    fable::assert_invalidate(s, TO_CONF(x));
+  }
+  for (const auto& x : {"true", "false"}) {
+    fable::assert_from_eq_to(s, TO_CONF(x));
+  }
+  fable::assert_schema_eq(s, R"({
+    "type": "string",
+    "description": "enum",
+    "enum": [ "true", "false" ]
+  })");
+}

--- a/fable/test_v2_package/CMakeLists.txt
+++ b/fable/test_v2_package/CMakeLists.txt
@@ -2,5 +2,10 @@ cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 project(fable_examples)
 
-add_subdirectory(../examples/contacts contacts)
-add_subdirectory(../examples/simple_config simple_config)
+set(examples_prefix ".")
+if (AS_TEST_PACKAGE)
+    set(examples_prefix "../examples")
+endif()
+
+add_subdirectory(${examples_prefix}/contacts contacts)
+add_subdirectory(${examples_prefix}/simple_config simple_config)

--- a/fable/test_v2_package/NOTE
+++ b/fable/test_v2_package/NOTE
@@ -3,7 +3,7 @@ Note on `test_v2_package`.
 The standard naming for the test package is `test_package`.
 Conan will pick this up automatically and then build it.
 However, when using a lockfile, Conan runs into an error
-when trying to build this lockfile.
+when trying to build this test package.
 
 Once we have migrated to using Conan 2.0, we will rename this
 directory to `test_package`.


### PR DESCRIPTION
There are these changes to the Fable library:

New:
- Add `String` schema `enum_of` method to specify valid values of string.
- Add `String` schema unit tests to test all features.
- Extend utility header `gtest.hpp` to support `Schema` type where previously only `Confable` type was supported.

Changed:
- Remove include of `fable/schema.hpp` in `fable/confable.hpp`. This allows better compile-time optimization but may require users to include `fable/schema.hpp` themselves.
- Update example projects to use modern CMake commands in Makefile.
- Update Conan test package `test_v2_package` to support `conan create .` outside of test package mode.

Performance:
- Extract String implementation from header.
- Extract Boolean implementation from header.
- Extract Number implementation from header.
  If a user uses a Number with a non-standard numeric type, then they need to
  include `number_impl.hpp`