### PR TITLE
Remove ubuntu-18.04 from Github workflows

### DIFF
--- a/.github/workflows/build-cloe.yaml
+++ b/.github/workflows/build-cloe.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         build_type: [RelWithDebInfo]
         package_target: [package]
     env:


### PR DESCRIPTION
This version of Ubuntu is no longer supported.