### PR TITLE
vtd: Fix missing f string in conanfiles

### DIFF
--- a/optional/vtd/vendor/vtd-api-2.2.0/conanfile.py
+++ b/optional/vtd/vendor/vtd-api-2.2.0/conanfile.py
@@ -74,7 +74,7 @@ class VtdApiConan(ConanFile):
         #
         # VTD VERSION   : (0)       2        . 2     . 0
         vtd_api_version = (0<<24) | (2<<16) | (2<<8) | 0
-        self.cpp_info.defines = ["VTD_API_VERSION={vtd_api_version}"]
+        self.cpp_info.defines = [f"VTD_API_VERSION={vtd_api_version}"]
 
         if not self.in_local_cache:
             self.cpp_info.libs = ["vtd_api"]

--- a/optional/vtd/vendor/vtd-api-2022.3/conanfile.py
+++ b/optional/vtd/vendor/vtd-api-2022.3/conanfile.py
@@ -74,7 +74,7 @@ class VtdApiConan(ConanFile):
         #
         # VTD VERSION   : (1)       2022     . 03
         vtd_api_version = (1<<24) | (22<<16) | (3<<8) | 0
-        self.cpp_info.defines = ["VTD_API_VERSION={vtd_api_version}"]
+        self.cpp_info.defines = [f"VTD_API_VERSION={vtd_api_version}"]
 
         if not self.in_local_cache:
             self.cpp_info.libs = ["vtd_api"]


### PR DESCRIPTION
vtd_api_version was not used before due to missing f string character