### PR TITLE
ui: Add proper file type for gzip upload

### DIFF
--- a/ui/src/components/navbar.jsx
+++ b/ui/src/components/navbar.jsx
@@ -35,7 +35,7 @@ function NavBar(props) {
         props.getSimulationDataFromJSON(file, e.target.result);
       };
       reader.readAsText(file);
-    } else if (file.type === "application/x-gzip") {
+    } else if (file.type === "application/x-gzip" || file.type === "application/gzip") {
       const fd = new FormData();
       fd.append("uploaded_file", file);
       const config = {


### PR DESCRIPTION
small bugfix in the ui where users could not upload a gzip json properly due to wrong assumption in application type
application/x-gzip stands for experimental while application/gzip is the proper type for that.
