### PR TITLE
Fix and improve development tooling

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,14 @@
+---
+Checks: >
+    modernize-*,
+    bugprone-*,
+    cppcoreguidelines-*,
+    cert-*,
+    misc-*,
+    performance-*,
+    readability-*,
+    -modernize-use-trailing-return-type,
+    -readability-identifier-length,
+    -readability-redundant-access-specifiers,
+    -readability-else-after-return,
+FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
     misc-*,
     performance-*,
     readability-*,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
     -modernize-use-trailing-return-type,
     -readability-identifier-length,
     -readability-redundant-access-specifiers,

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,26 +7,22 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+trim_trailing_whitespace = true
 
 [Makefile*]
 indent_style = tab
 
-[*.json]
+[*.{json,yaml,yml}]
 indent_size = 2
-trim_trailing_whitespace = true
 
-[*.{h,hpp,c,cc,cpp}]
+[*.{h,hpp,c,cc,cpp,hxx,cxx}]
 indent_size = 2
-trim_trailing_whitespace = true
 
-[*.json]
-indent_size = 2
-trim_trailing_whitespace = true
+[*.lua]
+indent_size = 4
 
 [*.html]
 indent_size = 2
-trim_trailing_whitespace = true
 
 [*.rst]
 indent_size = 4
-trim_trailing_whitespace = true

--- a/Makefile.all
+++ b/Makefile.all
@@ -171,8 +171,7 @@ help::
 	echo
 
 $(call make_select_target, all-select, "build selected packages", "[in-source]")
-$(call make_select_target, conan-select, "configure Conan and get dependencies", "[in-source]")
-$(call make_select_target, configure-select, "configure CMake packages", "[in-source]")
+$(call make_select_target, configure-select, "install dependencies and configure packages", "[in-source]")
 $(call make_select_target, test-select, "run CMake tests if they are available", "[in-source]")
 $(call make_select_target, export-pkg-select, "export build artifacts to Conan cache", "[in-source]")
 $(call make_select_target, clean-select, "remove build artifacts", "[in-source]")

--- a/Makefile.package
+++ b/Makefile.package
@@ -79,7 +79,6 @@ BUILD_DIR        := build
 
 # Don't change these unless you know what you are doing.
 BUILD_CONANINFO  := ${BUILD_DIR}/conanbuildinfo.txt
-BUILD_CMAKECACHE := ${BUILD_DIR}/CMakeCache.txt
 BUILD_LOCKFILE   := ${BUILD_DIR}/conan.lock
 
 # Default Conan build policy to use when installing Conan dependencies
@@ -202,8 +201,7 @@ ifeq (${BUILD_IN_SOURCE}, true)
 	$(call print_help_target, uneditable, "instruct Conan to use local cache")
 	echo
 	$(call print_help_target, all, "build the package", "[in-source]")
-	$(call print_help_target, conan, "configure Conan and install dependencies", "[in-source]")
-	$(call print_help_target, configure, "configure CMake package", "[in-source]")
+	$(call print_help_target, configure, "install dependencies and configure package", "[in-source]")
 	$(call print_help_target, test, "run CMake tests if they are available", "[in-source]")
 	$(call print_help_target, export-pkg, "export build artifacts to Conan cache", "[in-source]")
 ifeq (${CLEAN_SOURCE_DIR}, true)
@@ -423,13 +421,16 @@ clean:
 	#
 	rm -rf "${BUILD_DIR}"
 	rm -rf __pycache__
+	rm -f CMakeUserPresets.json
+	rm -f compile_commands.json
+	rm -f graph_info.json
 ifeq (${CLEAN_SOURCE_DIR}, true)
 	[ "${SOURCE_DIR}" != "." ] && rm -rf "${SOURCE_DIR}"
 endif
 
 ifeq (${BUILD_IN_SOURCE}, false)
-.PHONY: all conan configure test export-pkg
-all conan configure test export-pkg ${SOURCE_DIR} ${SOURCE_CMAKELISTS} ${BUILD_CONANINFO} ${BUILD_CMAKECACHE}:
+.PHONY: all configure test export-pkg
+all configure test export-pkg ${SOURCE_DIR} ${SOURCE_CMAKELISTS} ${BUILD_CONANINFO}:
 	@echo "Error: [in-source] targets are not supported for this package."
 	@echo "Note: please use [conan-cache] targets, such as 'package'."
 	exit 1
@@ -440,11 +441,9 @@ all: ${BUILD_CONANINFO} | ${SOURCE_DIR}
 	#
 	conan build . --source-folder="${SOURCE_DIR}" --install-folder="${BUILD_DIR}"
 
-.PHONY: conan
-conan: ${BUILD_CONANINFO}
-
 .PHONY: configure
-configure: ${BUILD_CMAKECACHE}
+configure: ${BUILD_CONANINFO}
+	ln -rsf "$$(dirname $$(dirname $$(jq -r '.include[0]' CMakeUserPresets.json)))/compile_commands.json"
 
 .PHONY: test
 test:
@@ -481,15 +480,11 @@ ${SOURCE_DIR}:
 
 ${SOURCE_CMAKELISTS}: | ${SOURCE_DIR}
 
-${BUILD_CONANINFO}: ${SOURCE_CONANFILE} ${BUILD_LOCKFILE}
-	# Install package dependencies and prepare in-source build.
+${BUILD_CONANINFO}: ${SOURCE_CONANFILE} ${BUILD_LOCKFILE} ${SOURCE_CMAKELISTS}
+	# Install package dependencies and configure in-source build.
 	#
 	mkdir -p "${BUILD_DIR}"
 	conan install . ${PACKAGE_FQN} --install-folder="${BUILD_DIR}" --build=${BUILD_POLICY} ${ALL_OPTIONS}
-	touch ${BUILD_CONANINFO}
-
-${BUILD_CMAKECACHE}: ${SOURCE_CMAKELISTS} ${BUILD_CONANINFO}
-	# Configure in-source build with CMake.
-	#
 	conan build --configure . --source-folder="${SOURCE_DIR}" --install-folder="${BUILD_DIR}"
+	touch ${BUILD_CONANINFO}
 endif

--- a/Makefile.setup
+++ b/Makefile.setup
@@ -61,7 +61,7 @@ setup-git:
 .PHONY: setup-conan
 setup-conan:
 	# Install Conan if it is not available.
-	if ! command -v conan >/dev/null 2>&1; then ${PIP} install --user conan; fi
+	if ! command -v conan >/dev/null 2>&1; then ${PIP} install --user --upgrade "conan<2"; fi
 	# Initialize Conan configuration if it doesn't already exist.
 	#
 	# Since running any conan command, even conan --help creates ${CONAN_DIR}

--- a/Makefile.setup
+++ b/Makefile.setup
@@ -108,19 +108,20 @@ install-ubuntu-deps::
 		build-essential \
 		clang-format \
 		cmake \
-		doxygen \
 		curl \
+		doxygen \
 		file \
 		git \
 		graphviz \
 		jq \
+		netcat-openbsd \
 		patchelf \
 		psmisc \
-		python3-setuptools \
 		python3-pip \
-        python3-venv \
+		python3-setuptools \
 		time \
 		tmux \
+		python3-venv \
 		;
 
 	# Require GCC and G++ version >= 8

--- a/engine/conanfile.py
+++ b/engine/conanfile.py
@@ -74,13 +74,17 @@ class CloeEngine(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/engine/conanfile.py
+++ b/engine/conanfile.py
@@ -82,9 +82,22 @@ class CloeEngine(ConanFile):
             cm.test()
 
     def package(self):
-        cm = cmake.CMake(self)
         if self.should_install:
+            cm = cmake.CMake(self)
             cm.install()
+
+            # Package license files for compliance
+            for meta, dep in self.dependencies.items():
+                if dep.package_folder is None:
+                    continue
+                ref = str(meta.ref)
+                name = ref[: str(ref).index("/")]
+                files.copy(
+                    self,
+                    "*",
+                    src=os.path.join(dep.package_folder, "licenses"),
+                    dst=os.path.join(self.package_folder, "licenses", name),
+                )
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/fable/conanfile.py
+++ b/fable/conanfile.py
@@ -63,13 +63,17 @@ class Fable(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/models/conanfile.py
+++ b/models/conanfile.py
@@ -60,13 +60,17 @@ class CloeModels(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/oak/conanfile.py
+++ b/oak/conanfile.py
@@ -59,13 +59,17 @@ class CloeOak(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         del self.info.options.pedantic

--- a/optional/vtd/conanfile.py
+++ b/optional/vtd/conanfile.py
@@ -112,21 +112,25 @@ class CloeSimulatorVTD(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         vtd_api_version = self.dependencies["vtd-api"].ref.version
 
         cm = cmake.CMake(self)
-        cm.install()
-        self.copy("vtd-launch", dst="bin", src=f"{self.source_folder}/bin")
-        self.copy(
-            "*.tar",
-            dst=self._setup_folder,
-            src=f"{self.source_folder}/{self._setup_folder}/{vtd_api_version}"
-        )
+        if self.should_install:
+            cm.install()
+            self.copy("vtd-launch", dst="bin", src=f"{self.source_folder}/bin")
+            self.copy(
+                "*.tar",
+                dst=self._setup_folder,
+                src=f"{self.source_folder}/{self._setup_folder}/{vtd_api_version}"
+            )
 
     def package_id(self):
         # Changes in a dependency's package_id need to be accounted for since

--- a/optional/vtd/vendor/vtd-api-2.2.0/conanfile.py
+++ b/optional/vtd/vendor/vtd-api-2.2.0/conanfile.py
@@ -48,13 +48,16 @@ class VtdApiConan(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
-        files.copy(self, "Develop", src="src", dst=".")
+        if self.should_install:
+            cm.install()
+            files.copy(self, "Develop", src="src", dst=".")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/optional/vtd/vendor/vtd-api-2022.3/conanfile.py
+++ b/optional/vtd/vendor/vtd-api-2022.3/conanfile.py
@@ -48,13 +48,16 @@ class VtdApiConan(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
-        files.copy(self, "Develop", src="src", dst=".")
+        if self.should_install:
+            cm.install()
+            files.copy(self, "Develop", src="src", dst=".")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/plugins/basic/conanfile.py
+++ b/plugins/basic/conanfile.py
@@ -57,13 +57,17 @@ class CloeControllerBasic(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/plugins/gndtruth_extractor/conanfile.py
+++ b/plugins/gndtruth_extractor/conanfile.py
@@ -56,13 +56,17 @@ class CloeControllerGndtruthExtractor(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/plugins/minimator/conanfile.py
+++ b/plugins/minimator/conanfile.py
@@ -56,12 +56,15 @@ class CloeSimulatorMinimator(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/plugins/mocks/conanfile.py
+++ b/plugins/mocks/conanfile.py
@@ -53,12 +53,15 @@ class CloeControllerMocks(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/plugins/noisy_sensor/conanfile.py
+++ b/plugins/noisy_sensor/conanfile.py
@@ -56,13 +56,17 @@ class CloeComponentNoisySensor(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/plugins/speedometer/conanfile.py
+++ b/plugins/speedometer/conanfile.py
@@ -53,12 +53,15 @@ class CloeComponentKmph(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/plugins/virtue/conanfile.py
+++ b/plugins/virtue/conanfile.py
@@ -53,12 +53,15 @@ class CloeControllerVirtue(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/runtime/conanfile.py
+++ b/runtime/conanfile.py
@@ -64,13 +64,17 @@ class CloeRuntime(ConanFile):
 
     def build(self):
         cm = cmake.CMake(self)
-        cm.configure()
-        cm.build()
-        cm.test()
+        if self.should_configure:
+            cm.configure()
+        if self.should_build:
+            cm.build()
+        if self.should_test:
+            cm.test()
 
     def package(self):
         cm = cmake.CMake(self)
-        cm.install()
+        if self.should_install:
+            cm.install()
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()

--- a/runtime/conanfile.py
+++ b/runtime/conanfile.py
@@ -84,9 +84,8 @@ class CloeRuntime(ConanFile):
 
         # Make sure we can find the libs and *.cmake files, both in editable
         # mode and in the normal package mode:
-        # TODO: Is this still necessarytools?
         if not self.in_local_cache:
-            self.cpp_info.builddirs.append("cmake")
+            self.cpp_info.builddirs.append(os.path.join(self.source_folder, "cmake"))
             self.cpp_info.libs = ["cloe-runtime"]
         else:
             self.cpp_info.builddirs.append(os.path.join("lib", "cmake", "cloe"))


### PR DESCRIPTION
New:
- Add Clang Tidy configuration file

Improved:
- Changed `configure` target in `Makefile.package` to link `compile_commands.json` automatically

Changed:
- Removed `conan-select` target from `Makefile.all`
- Removed `conan` target from `Makefile.package`

Fixed:
- Fixed `setup-conan` target in `Makefile.setup` to install Conan version 1.x
- Fixed recipes to respect Conan `--build`, `--test`, `--configure`, and `--install` arguments
