### PR TITLE
Remove outdated ifndef-define-endif header guards

### DIFF
--- a/engine/src/plugins/nop_controller.hpp
+++ b/engine/src/plugins/nop_controller.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_CONTROLLER_NOP_HPP_
-#define CLOE_CONTROLLER_NOP_HPP_
 
 #include <cloe/controller.hpp>  // for DEFINE_CONTROLLER_FACTORY, Json, ...
 
@@ -42,5 +40,3 @@ DEFINE_CONTROLLER_FACTORY(NopFactory, NopConfiguration, "nop", "stand-in that do
 
 }  // namespace controller
 }  // namespace cloe
-
-#endif  // CLOE_CONTROLLER_NOP_HPP_

--- a/engine/src/plugins/nop_simulator.hpp
+++ b/engine/src/plugins/nop_simulator.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_SIMULATOR_NOP_HPP_
-#define CLOE_SIMULATOR_NOP_HPP_
 
 #include <memory>  // for unique_ptr<>
 #include <string>  // for string
@@ -53,5 +51,3 @@ DEFINE_SIMULATOR_FACTORY(NopFactory, NopConfiguration, "nop", "stand-in no-opera
 
 }  // namespace simulator
 }  // namespace cloe
-
-#endif  // CLOE_SIMULATOR_NOP_HPP_

--- a/engine/src/utility/defer.hpp
+++ b/engine/src/utility/defer.hpp
@@ -19,6 +19,8 @@
  * \file defer.hpp
  */
 
+#pragma once
+
 #include <functional> // for function<>
 
 namespace engine {

--- a/fable/include/fable/conf.hpp
+++ b/fable/include/fable/conf.hpp
@@ -49,8 +49,6 @@
  */
 
 #pragma once
-#ifndef FABLE_CONF_HPP_
-#define FABLE_CONF_HPP_
 
 #include <functional>  // for function<>
 #include <string>      // for string
@@ -348,5 +346,3 @@ class Conf {
 };
 
 }  // namespace fable
-
-#endif  // FABLE_CONF_HPP_

--- a/fable/include/fable/confable.hpp
+++ b/fable/include/fable/confable.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_CONFABLE_HPP_
-#define FABLE_CONFABLE_HPP_
 
 #include <memory>  // for unique_ptr<>
 
@@ -138,5 +136,3 @@ struct adl_serializer<fable::Confable> {
 };
 
 }  // namespace nlohmann
-
-#endif  // FABLE_CONFABLE_HPP_

--- a/fable/include/fable/enum.hpp
+++ b/fable/include/fable/enum.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef FABLE_ENUM_HPP_
-#define FABLE_ENUM_HPP_
 
 #include <map>          // for map<>
 #include <string>       // for string
@@ -172,5 +170,3 @@ T from_string(const std::string& s) {
 }
 
 }  // namespace fable
-
-#endif  // FABLE_ENUM_HPP_

--- a/fable/include/fable/environment.hpp
+++ b/fable/include/fable/environment.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_ENVIRONMENT_HPP_
-#define FABLE_ENVIRONMENT_HPP_
 
 #include <cassert>  // for assert
 #include <map>      // for map<>
@@ -134,5 +132,3 @@ inline std::string interpolate_vars(const std::string& s, const Environment* env
 }
 
 }  // namespace fable
-
-#endif  // FABLE_ENVIRONMENT_HPP_

--- a/fable/include/fable/error.hpp
+++ b/fable/include/fable/error.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef FABLE_ERROR_HPP_
-#define FABLE_ERROR_HPP_
 
 #include <stdexcept>  // for exception
 #include <string>     // for string
@@ -154,5 +152,3 @@ class SchemaError : public ConfError {
 };
 
 }  // namespace fable
-
-#endif  // FABLE_ERROR_HPP_

--- a/fable/include/fable/fable.hpp
+++ b/fable/include/fable/fable.hpp
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef FABLE_FABLE_HPP_
-#define FABLE_FABLE_HPP_
 
 #include <fable/conf.hpp>
 #include <fable/confable.hpp>
@@ -34,5 +32,3 @@
 #include <fable/json.hpp>
 #include <fable/json/with_std.hpp>
 #include <fable/schema.hpp>
-
-#endif  // FABLE_FABLE_HPP_

--- a/fable/include/fable/json.hpp
+++ b/fable/include/fable/json.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef FABLE_JSON_HPP_
-#define FABLE_JSON_HPP_
 
 #include <string>  // for string
 
@@ -108,5 +106,3 @@ inline Json parse_json(InputType&& input) {
 }
 
 }  // namespace fable
-
-#endif  // FABLE_JSON_HPP_

--- a/fable/include/fable/json/with_boost.hpp
+++ b/fable/include/fable/json/with_boost.hpp
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef FABLE_JSON_WITH_BOOST_HPP_
-#define FABLE_JSON_WITH_BOOST_HPP_
 
 #include <nlohmann/json.hpp>
 
@@ -61,5 +59,3 @@ struct adl_serializer<boost::optional<T>> {
 };
 
 }  // namespace nlohmann
-
-#endif  // FABLE_JSON_WITH_BOOST_HPP_

--- a/fable/include/fable/json/with_eigen.hpp
+++ b/fable/include/fable/json/with_eigen.hpp
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef FABLE_JSON_WITH_EIGEN_HPP_
-#define FABLE_JSON_WITH_EIGEN_HPP_
 
 #include <nlohmann/json.hpp>
 
@@ -87,5 +85,3 @@ struct adl_serializer<Eigen::Isometry3d> {
 };
 
 }  // namespace nlohmann
-
-#endif  // FABLE_JSON_WITH_EIGEN_HPP_

--- a/fable/include/fable/json/with_std.hpp
+++ b/fable/include/fable/json/with_std.hpp
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef FABLE_JSON_WITH_STD_HPP_
-#define FABLE_JSON_WITH_STD_HPP_
 
 #include <memory>  // for unique_ptr<>, shared_ptr<>, weak_ptr<>
 
@@ -76,5 +74,3 @@ struct adl_serializer<std::weak_ptr<T>> {
 };
 
 }  // namespace nlohmann
-
-#endif  // FABLE_JSON_WITH_STD_HPP_

--- a/fable/include/fable/schema.hpp
+++ b/fable/include/fable/schema.hpp
@@ -113,8 +113,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_HPP_
-#define FABLE_SCHEMA_HPP_
 
 #include <chrono>       // for duration<>
 #include <map>          // for map<>
@@ -269,5 +267,3 @@ class Schema : public schema::Interface {
 };
 
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_HPP_

--- a/fable/include/fable/schema/array.hpp
+++ b/fable/include/fable/schema/array.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_ARRAY_HPP_
-#define FABLE_SCHEMA_ARRAY_HPP_
 
 #include <limits>       // for numeric_limits<>
 #include <memory>       // for shared_ptr<>
@@ -182,5 +180,3 @@ Array<T, P> make_schema(std::vector<T>* ptr, const P& prototype, std::string&& d
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_ARRAY_HPP_

--- a/fable/include/fable/schema/boolean.hpp
+++ b/fable/include/fable/schema/boolean.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_BOOLEAN_HPP_
-#define FABLE_SCHEMA_BOOLEAN_HPP_
 
 #include <string>   // for string
 #include <utility>  // for move
@@ -57,5 +55,3 @@ inline Boolean make_schema(bool* ptr, std::string&& desc) { return Boolean(ptr, 
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_BOOLEAN_HPP_

--- a/fable/include/fable/schema/confable.hpp
+++ b/fable/include/fable/schema/confable.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_CONFABLE_HPP_
-#define FABLE_SCHEMA_CONFABLE_HPP_
 
 #include <memory>   // for shared_ptr<>
 #include <string>   // for string
@@ -110,5 +108,3 @@ FromConfable<T> make_schema(T* ptr, std::string&& desc) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_CONFABLE_HPP_

--- a/fable/include/fable/schema/const.hpp
+++ b/fable/include/fable/schema/const.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_CONST_HPP_
-#define FABLE_SCHEMA_CONST_HPP_
 
 #include <string>   // for string
 #include <utility>  // for move
@@ -105,5 +103,3 @@ inline Const<std::string, String> make_const_str(const char* constant, std::stri
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_CONST_HPP_

--- a/fable/include/fable/schema/custom.hpp
+++ b/fable/include/fable/schema/custom.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_CUSTOM_HPP_
-#define FABLE_SCHEMA_CUSTOM_HPP_
 
 #include <functional>  // for function<>
 
@@ -93,5 +91,3 @@ class CustomDeserializer : public schema::Interface {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_CUSTOM_HPP_

--- a/fable/include/fable/schema/duration.hpp
+++ b/fable/include/fable/schema/duration.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_DURATION_HPP_
-#define FABLE_SCHEMA_DURATION_HPP_
 
 #include <chrono>   // for duration<>
 #include <limits>   // for numeric_limits<>
@@ -196,5 +194,3 @@ inline Duration<Rep, Period> make_schema(std::chrono::duration<Rep, Period>* ptr
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_DURATION_HPP_

--- a/fable/include/fable/schema/enum.hpp
+++ b/fable/include/fable/schema/enum.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_ENUM_HPP_
-#define FABLE_SCHEMA_ENUM_HPP_
 
 #include <map>          // for map<>
 #include <string>       // for string
@@ -111,5 +109,3 @@ inline Enum<T> make_schema(T* ptr, std::string&& desc) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_ENUM_HPP_

--- a/fable/include/fable/schema/factory.hpp
+++ b/fable/include/fable/schema/factory.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_FACTORY_HPP_
-#define FABLE_SCHEMA_FACTORY_HPP_
 
 #include <functional>   // for function<>
 #include <limits>       // for numeric_limits<>
@@ -420,5 +418,3 @@ class Factory : public FactoryBase<T, Factory<T>> {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_FACTORY_HPP_

--- a/fable/include/fable/schema/ignore.hpp
+++ b/fable/include/fable/schema/ignore.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_IGNORE_HPP_
-#define FABLE_SCHEMA_IGNORE_HPP_
 
 #include <string>   // for string
 #include <utility>  // for move
@@ -68,5 +66,3 @@ inline Ignore make_schema(std::string&& desc, JsonType t = JsonType::object) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_IGNORE_HPP_

--- a/fable/include/fable/schema/interface.hpp
+++ b/fable/include/fable/schema/interface.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_INTERFACE_HPP_
-#define FABLE_SCHEMA_INTERFACE_HPP_
 
 #include <memory>       // for shared_ptr<>
 #include <string>       // for string
@@ -467,5 +465,3 @@ auto make_prototype(std::string&& desc = "");
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_INTERFACE_HPP_

--- a/fable/include/fable/schema/json.hpp
+++ b/fable/include/fable/schema/json.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_JSON_HPP_
-#define FABLE_SCHEMA_JSON_HPP_
 
 #include <string>   // for string
 #include <utility>  // for move
@@ -88,5 +86,3 @@ inline FromJson<T> make_schema(T* ptr, JsonType t, std::string&& desc) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_JSON_HPP_

--- a/fable/include/fable/schema/magic.hpp
+++ b/fable/include/fable/schema/magic.hpp
@@ -34,8 +34,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_MAGIC_HPP_
-#define FABLE_SCHEMA_MAGIC_HPP_
 
 #include <map>      // for map<>
 #include <string>   // for string
@@ -105,5 +103,3 @@ auto make_prototype(std::string&& desc) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_MAGIC_HPP_

--- a/fable/include/fable/schema/map.hpp
+++ b/fable/include/fable/schema/map.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_MAP_HPP_
-#define FABLE_SCHEMA_MAP_HPP_
 
 #include <limits>   // for numeric_limits<>
 #include <map>      // for map<>
@@ -197,5 +195,3 @@ Map<T, P> make_schema(std::map<std::string, T>* ptr, const P& prototype, std::st
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_MAP_HPP_

--- a/fable/include/fable/schema/number.hpp
+++ b/fable/include/fable/schema/number.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_NUMBER_HPP_
-#define FABLE_SCHEMA_NUMBER_HPP_
 
 #include <initializer_list>  // for initializer_list<>
 #include <set>               // for set<>
@@ -112,5 +110,3 @@ inline Number<T> make_schema(T* ptr, std::string&& desc) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_NUMBER_HPP_

--- a/fable/include/fable/schema/number_impl.hpp
+++ b/fable/include/fable/schema/number_impl.hpp
@@ -25,8 +25,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_NUMBER_IMPL_HPP_
-#define FABLE_SCHEMA_NUMBER_IMPL_HPP_
 
 #include <initializer_list>  // for initializer_list<>
 #include <limits>            // for numeric_limits<>
@@ -265,5 +263,3 @@ void Number<T>::check_bounds(const Conf& c) const {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_NUMBER_IMPL_HPP_

--- a/fable/include/fable/schema/optional.hpp
+++ b/fable/include/fable/schema/optional.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_OPTIONAL_HPP_
-#define FABLE_SCHEMA_OPTIONAL_HPP_
 
 #include <string>   // for string
 #include <utility>  // for move
@@ -121,5 +119,3 @@ Optional<T, P> make_schema(boost::optional<T>* ptr, const P& prototype, std::str
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_OPTIONAL_HPP_

--- a/fable/include/fable/schema/passthru.hpp
+++ b/fable/include/fable/schema/passthru.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_PASSTHRU_HPP_
-#define FABLE_SCHEMA_PASSTHRU_HPP_
 
 #include <string>   // for string
 #include <utility>  // for move
@@ -105,5 +103,3 @@ Passthru<P> make_schema(Conf* ptr, const P& prototype, std::string&& desc) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_PASSTHRU_HPP_

--- a/fable/include/fable/schema/path.hpp
+++ b/fable/include/fable/schema/path.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_PATH_HPP_
-#define FABLE_SCHEMA_PATH_HPP_
 
 #include <limits>   // for numeric_limits<>
 #include <string>   // for string
@@ -231,5 +229,3 @@ struct adl_serializer<boost::filesystem::path> {
 };
 
 }  // namespace nlohmann
-
-#endif  // FABLE_SCHEMA_PATH_HPP_

--- a/fable/include/fable/schema/string.hpp
+++ b/fable/include/fable/schema/string.hpp
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_STRING_HPP_
-#define FABLE_SCHEMA_STRING_HPP_
 
 #include <limits>   // for numeric_limits<>
 #include <string>   // for string
@@ -269,5 +267,3 @@ inline String make_schema(std::string* ptr, std::string&& desc) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_STRING_HPP_

--- a/fable/include/fable/schema/struct.hpp
+++ b/fable/include/fable/schema/struct.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_STRUCT_HPP_
-#define FABLE_SCHEMA_STRUCT_HPP_
 
 #include <map>          // for map<>
 #include <memory>       // for shared_ptr<>
@@ -241,5 +239,3 @@ inline Struct make_schema(std::string&& desc, const Struct& base, T&& props) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_STRUCT_HPP_

--- a/fable/include/fable/schema/variant.hpp
+++ b/fable/include/fable/schema/variant.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef FABLE_SCHEMA_VARIANT_HPP_
-#define FABLE_SCHEMA_VARIANT_HPP_
 
 #include <string>   // for string
 #include <utility>  // for move
@@ -139,5 +137,3 @@ inline Variant make_schema(std::string&& desc, std::vector<Box>&& vec) {
 
 }  // namespace schema
 }  // namespace fable
-
-#endif  // FABLE_SCHEMA_VARIANT_HPP_

--- a/fable/include/fable/utility.hpp
+++ b/fable/include/fable/utility.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef FABLE_UTILITY_HPP_
-#define FABLE_UTILITY_HPP_
 
 #include <string>  // for string
 
@@ -78,5 +76,3 @@ void pretty_print(const ConfError& e, std::ostream& os);
 void pretty_print(const SchemaError& e, std::ostream& os);
 
 }  // namespace fable
-
-#endif  // FABLE_UTILITY_HPP_

--- a/fable/include/fable/utility/gtest.hpp
+++ b/fable/include/fable/utility/gtest.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef FABLE_UTILITY_GTEST_HPP_
-#define FABLE_UTILITY_GTEST_HPP_
 
 #include <iostream>  // for cerr
 
@@ -188,5 +186,3 @@ inline void assert_from_eq_to(T& x, const char json_input[]) {
 }
 
 }  // namespace fable
-
-#endif  // FABLE_UTILITY_GTEST_HPP_

--- a/models/include/cloe/component/actuator.hpp
+++ b/models/include/cloe/component/actuator.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_ACTUATOR_HPP_
-#define CLOE_COMPONENT_ACTUATOR_HPP_
 
 #include <boost/optional.hpp>  // for optional
 #include <cloe/component.hpp>  // for Component
@@ -57,5 +55,3 @@ class Actuator : public Component {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_ACTUATOR_HPP_

--- a/models/include/cloe/component/brake_sensor.hpp
+++ b/models/include/cloe/component/brake_sensor.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_BRAKE_SENSOR_HPP_
-#define CLOE_COMPONENT_BRAKE_SENSOR_HPP_
 
 #include <cloe/component.hpp>  // for Component, Json
 
@@ -66,5 +64,3 @@ class NopBrakeSensor : public BrakeSensor {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_BRAKE_SENSOR_HPP_

--- a/models/include/cloe/component/driver_request.hpp
+++ b/models/include/cloe/component/driver_request.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_DRIVER_REQUEST_HPP_
-#define CLOE_COMPONENT_DRIVER_REQUEST_HPP_
 
 #include <cloe/component.hpp>  // for Component, Json
 
@@ -98,5 +96,3 @@ class NopDriverRequest : public DriverRequest {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_DRIVER_REQUEST_HPP_

--- a/models/include/cloe/component/ego_sensor.hpp
+++ b/models/include/cloe/component/ego_sensor.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_EGO_SENSOR_HPP_
-#define CLOE_COMPONENT_EGO_SENSOR_HPP_
 
 #include <cloe/component.hpp>         // for Component, Json
 #include <cloe/component/object.hpp>  // for Object
@@ -92,5 +90,3 @@ class NopEgoSensor : public EgoSensor {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_EGO_SENSOR_HPP_

--- a/models/include/cloe/component/frustum.hpp
+++ b/models/include/cloe/component/frustum.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_FRUSTUM_HPP_
-#define CLOE_COMPONENT_FRUSTUM_HPP_
 
 #include <cmath>  // for M_PI
 
@@ -77,5 +75,3 @@ struct Frustum : public Confable {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_FRUSTUM_HPP_

--- a/models/include/cloe/component/gearbox_actuator.hpp
+++ b/models/include/cloe/component/gearbox_actuator.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_GEARBOX_ACTUATOR_HPP_
-#define CLOE_COMPONENT_GEARBOX_ACTUATOR_HPP_
 
 #include <cloe/component/actuator.hpp>  // for Actuator
 #include <fable/json.hpp>               // for Json
@@ -53,5 +51,3 @@ class GearboxActuator : public Actuator<GearboxRequest> {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_GEARBOX_ACTUATOR_HPP_

--- a/models/include/cloe/component/lane_boundary.hpp
+++ b/models/include/cloe/component/lane_boundary.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_LANE_BOUNDARY_HPP_
-#define CLOE_COMPONENT_LANE_BOUNDARY_HPP_
 
 #include <map>     // for map
 #include <vector>  // for vector
@@ -95,5 +93,3 @@ ENUM_SERIALIZATION(LaneBoundary::Color, ({
 // clang-format on
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_LANE_BOUNDARY_HPP_

--- a/models/include/cloe/component/lane_sensor.hpp
+++ b/models/include/cloe/component/lane_sensor.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_LANE_SENSOR_HPP_
-#define CLOE_COMPONENT_LANE_SENSOR_HPP_
 
 #include <Eigen/Geometry>             // for Isometry3d
 #include <fable/json/with_eigen.hpp>  // for to_json
@@ -77,5 +75,3 @@ class NopLaneSensor : public LaneBoundarySensor {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_LANE_SENSOR_HPP_

--- a/models/include/cloe/component/latlong_actuator.hpp
+++ b/models/include/cloe/component/latlong_actuator.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_LATLONG_ACTUATOR_HPP_
-#define CLOE_COMPONENT_LATLONG_ACTUATOR_HPP_
 
 #include <boost/optional.hpp>         // for optional<>
 #include <fable/json/with_boost.hpp>  // for to_json
@@ -132,5 +130,3 @@ class LatActuator : public Actuator<double> {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_LATLONG_ACTUATOR_HPP_

--- a/models/include/cloe/component/object.hpp
+++ b/models/include/cloe/component/object.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_OBJECT_HPP_
-#define CLOE_COMPONENT_OBJECT_HPP_
 
 #include <memory>  // for shared_ptr<>
 #include <vector>  // for vector<>
@@ -137,5 +135,3 @@ ENUM_SERIALIZATION(Object::Class, ({
 // clang-format on
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_OBJECT_HPP_

--- a/models/include/cloe/component/object_sensor.hpp
+++ b/models/include/cloe/component/object_sensor.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_OBJECT_SENSOR_HPP_
-#define CLOE_COMPONENT_OBJECT_SENSOR_HPP_
 
 #include <cloe/component.hpp>          // for Component, Json
 #include <cloe/component/frustum.hpp>  // for Frustum
@@ -92,5 +90,3 @@ class NopObjectSensor : public ObjectSensor {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_OBJECT_SENSOR_HPP_

--- a/models/include/cloe/component/object_sensor_functional.hpp
+++ b/models/include/cloe/component/object_sensor_functional.hpp
@@ -25,8 +25,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_OBJECT_SENSOR_FUNCTIONAL_HPP_
-#define CLOE_COMPONENT_OBJECT_SENSOR_FUNCTIONAL_HPP_
 
 #include <functional>  // for function
 #include <memory>      // for shared_ptr<>
@@ -243,5 +241,3 @@ class ObjectSensorFilterMap : public ObjectSensor {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_OBJECT_SENSOR_FUNCTIONAL_HPP_

--- a/models/include/cloe/component/pedal_actuator.hpp
+++ b/models/include/cloe/component/pedal_actuator.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_PEDAL_ACTUATOR_HPP_
-#define CLOE_COMPONENT_PEDAL_ACTUATOR_HPP_
 
 #include <cloe/component/actuator.hpp>  // for Actuator
 #include <fable/json.hpp>               // for Json
@@ -59,5 +57,3 @@ class PedalActuator : public Actuator<PedalRequest> {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_PEDAL_ACTUATOR_HPP_

--- a/models/include/cloe/component/powertrain_sensor.hpp
+++ b/models/include/cloe/component/powertrain_sensor.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_POWERTRAIN_SENSOR_HPP_
-#define CLOE_COMPONENT_POWERTRAIN_SENSOR_HPP_
 
 #include <cloe/component.hpp>  // for Component, Json
 
@@ -86,5 +84,3 @@ class NopPowertrainSensor : public PowertrainSensor {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_POWERTRAIN_SENSOR_HPP_

--- a/models/include/cloe/component/steering_actuator.hpp
+++ b/models/include/cloe/component/steering_actuator.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_STEERING_ACTUATOR_HPP_
-#define CLOE_COMPONENT_STEERING_ACTUATOR_HPP_
 
 #include <cloe/component/actuator.hpp>  // for Actuator
 #include <fable/json.hpp>               // for Json
@@ -55,5 +53,3 @@ class SteeringActuator : public Actuator<SteeringRequest> {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_STEERING_ACTUATOR_HPP_

--- a/models/include/cloe/component/steering_sensor.hpp
+++ b/models/include/cloe/component/steering_sensor.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_STEERING_SENSOR_HPP_
-#define CLOE_COMPONENT_STEERING_SENSOR_HPP_
 
 #include <cloe/component.hpp>  // for Component, Json
 
@@ -65,5 +63,3 @@ class NopSteeringSensor : public SteeringSensor {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_STEERING_SENSOR_HPP_

--- a/models/include/cloe/component/utility/ego_sensor_canon.hpp
+++ b/models/include/cloe/component/utility/ego_sensor_canon.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_UTILITY_EGO_SENSOR_CANON_HPP_
-#define CLOE_COMPONENT_UTILITY_EGO_SENSOR_CANON_HPP_
 
 #include <math.h>  // for fabs
 #include <memory>  // for shared_ptr<>
@@ -133,5 +131,3 @@ std::shared_ptr<Object> closest_forward(const Objects objects);
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_UTILITY_EGO_SENSOR_CANON_HPP_

--- a/models/include/cloe/component/utility/filter.hpp
+++ b/models/include/cloe/component/utility/filter.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_UTILITY_FILTER_HPP_
-#define CLOE_COMPONENT_UTILITY_FILTER_HPP_
 
 #include <vector>
 
@@ -66,5 +64,3 @@ F any_of(std::vector<F> fs) {
 }  // namespace filter
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_UTILITY_FILTER_HPP_

--- a/models/include/cloe/component/utility/steering_utils.hpp
+++ b/models/include/cloe/component/utility/steering_utils.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_UTILITY_STEERING_UTILS_HPP_
-#define CLOE_COMPONENT_UTILITY_STEERING_UTILS_HPP_
 
 namespace cloe {
 namespace utility {
@@ -54,5 +52,3 @@ double calculate_wheel_angle(const Geometry& geometry, WheelId wheel_id, double 
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_UTILITY_STEERING_UTILS_HPP_

--- a/models/include/cloe/component/vehicle_state_model.hpp
+++ b/models/include/cloe/component/vehicle_state_model.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_VEHICLE_STATE_MODEL_HPP_
-#define CLOE_COMPONENT_VEHICLE_STATE_MODEL_HPP_
 
 #include <functional>  // for function
 
@@ -124,5 +122,3 @@ class VehicleStateModel : public Component {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_VEHICLE_STATE_MODEL_HPP_

--- a/models/include/cloe/component/wheel.hpp
+++ b/models/include/cloe/component/wheel.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_WHEEL_HPP_
-#define CLOE_COMPONENT_WHEEL_HPP_
 
 #include <fable/json.hpp>  // for to_json
 
@@ -47,5 +45,3 @@ struct Wheel {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_WHEEL_HPP_

--- a/models/include/cloe/component/wheel_sensor.hpp
+++ b/models/include/cloe/component/wheel_sensor.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_WHEEL_SENSOR_HPP_
-#define CLOE_COMPONENT_WHEEL_SENSOR_HPP_
 
 #include <cloe/component.hpp>        // for Component, Json
 #include <cloe/component/wheel.hpp>  // for Wheel
@@ -96,5 +94,3 @@ class NopWheelSensor : public WheelSensor {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_WHEEL_SENSOR_HPP_

--- a/models/include/cloe/models.hpp
+++ b/models/include/cloe/models.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_STD_MODELS_HPP_
-#define CLOE_STD_MODELS_HPP_
 
 #include <string>  // for string
 
@@ -103,5 +101,3 @@ ENUM_SERIALIZATION(CloeComponent, ({
 inline std::string to_string(CloeComponent c) { return enum_serialization(c).at(c); }
 
 }  // namespace cloe
-
-#endif  // CLOE_STD_MODELS_HPP_

--- a/models/include/cloe/utility/actuation_level.hpp
+++ b/models/include/cloe/utility/actuation_level.hpp
@@ -37,8 +37,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_ACTUATION_LEVEL_HPP_
-#define CLOE_UTILITY_ACTUATION_LEVEL_HPP_
 
 #include <string>  // for string
 
@@ -185,5 +183,3 @@ inline std::string to_string(const ActuationLevel::Enum level) {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_ACTUATION_LEVEL_HPP_

--- a/models/include/cloe/utility/actuation_state.hpp
+++ b/models/include/cloe/utility/actuation_state.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_ACTUATION_STATE_HPP_
-#define CLOE_UTILITY_ACTUATION_STATE_HPP_
 
 #include <string>  // for string
 
@@ -113,5 +111,3 @@ struct ActuationStatistics {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_ACTUATION_STATE_HPP_

--- a/models/include/cloe/utility/geometry.hpp
+++ b/models/include/cloe/utility/geometry.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_GEOMETRY_HPP_
-#define CLOE_UTILITY_GEOMETRY_HPP_
 
 #include <Eigen/Geometry>
 
@@ -84,5 +82,3 @@ inline void transform_point_to_parent_frame(const Eigen::Isometry3d& child_frame
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_GEOMETRY_HPP_

--- a/models/include/cloe/utility/simple_steering_model.hpp
+++ b/models/include/cloe/utility/simple_steering_model.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_SIMPLE_STEERING_MODEL_HPP_
-#define CLOE_UTILITY_SIMPLE_STEERING_MODEL_HPP_
 
 namespace cloe {
 namespace utility {
@@ -82,5 +80,3 @@ class SimpleSteeringModel {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_SIMPLE_STEERING_MODEL_HPP_

--- a/optional/vtd/src/vtd_sensor_components.hpp
+++ b/optional/vtd/src/vtd_sensor_components.hpp
@@ -19,6 +19,8 @@
  * \file vtd_sensor_components.hpp
  */
 
+#pragma once
+
 #include <cloe/component/driver_request.hpp>  // for DriverRequest
 #include <cloe/component/ego_sensor.hpp>      // for EgoSensor
 #include <cloe/component/lane_sensor.hpp>     // for LaneBoundarySensor

--- a/plugins/gndtruth_extractor/src/bimap.hpp
+++ b/plugins/gndtruth_extractor/src/bimap.hpp
@@ -19,6 +19,8 @@
  * \file bimap.hpp
  */
 
+#pragma once
+
 #include <vector>  // for vector<>
 
 #include <boost/algorithm/string/join.hpp>  // for boost::algorithm::join

--- a/plugins/gndtruth_extractor/src/gndtruth_extractor.hpp
+++ b/plugins/gndtruth_extractor/src/gndtruth_extractor.hpp
@@ -19,6 +19,8 @@
  * \file gndtruth_extractor.hpp
  */
 
+#pragma once
+
 #include <cloe/core.hpp>  // for Confable, Schema
 
 namespace cloe {

--- a/runtime/include/cloe/component.hpp
+++ b/runtime/include/cloe/component.hpp
@@ -25,8 +25,6 @@
  */
 
 #pragma once
-#ifndef CLOE_COMPONENT_HPP_
-#define CLOE_COMPONENT_HPP_
 
 #include <cstdint>      // for uint64_t
 #include <memory>       // for shared_ptr<>, unique_ptr<>, make_unique<>
@@ -243,5 +241,3 @@ class ComponentFactory : public ModelFactory {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_COMPONENT_HPP_

--- a/runtime/include/cloe/conf/action.hpp
+++ b/runtime/include/cloe/conf/action.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_CONF_ACTION_HPP_
-#define CLOE_CONF_ACTION_HPP_
 
 #include <memory>   // for unique_ptr<>
 #include <string>   // for string
@@ -76,5 +74,3 @@ class ConfigureFactory : public ActionFactory {
 
 }  // namespace actions
 }  // namespace cloe
-
-#endif  // CLOE_CONF_ACTION_HPP_

--- a/runtime/include/cloe/controller.hpp
+++ b/runtime/include/cloe/controller.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef CLOE_CONTROLLER_HPP_
-#define CLOE_CONTROLLER_HPP_
 
 #include <memory>       // for shared_ptr<>, unique_ptr<>, make_unique<>
 #include <type_traits>  // for decay
@@ -198,5 +196,3 @@ class ControllerFactory : public ModelFactory {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_CONTROLLER_HPP_

--- a/runtime/include/cloe/core.hpp
+++ b/runtime/include/cloe/core.hpp
@@ -24,12 +24,8 @@
  */
 
 #pragma once
-#ifndef CLOE_CORE_HPP_
-#define CLOE_CORE_HPP_
 
 #include <cloe/core/duration.hpp>
 #include <cloe/core/error.hpp>
 #include <cloe/core/fable.hpp>
 #include <cloe/core/logger.hpp>
-
-#endif  // CLOE_CORE_HPP_

--- a/runtime/include/cloe/core/abort.hpp
+++ b/runtime/include/cloe/core/abort.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_CORE_ABORT_HPP_
-#define CLOE_CORE_ABORT_HPP_
 
 #include <atomic>     // for atomic_bool
 #include <stdexcept>  // for exception
@@ -64,5 +62,3 @@ inline void abort_checkpoint(AbortFlag& sig) {
 }
 
 }  // namespace cloe
-
-#endif  // CLOE_CORE_ABORT_HPP_

--- a/runtime/include/cloe/core/duration.hpp
+++ b/runtime/include/cloe/core/duration.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_CORE_DURATION_HPP_
-#define CLOE_CORE_DURATION_HPP_
 
 #include <chrono>  // for duration<>, duration_cast<>, nanoseconds
 #include <ratio>   // for micro, milli
@@ -111,5 +109,3 @@ struct adl_serializer<cloe::Duration> {
 };
 
 }  // namespace nlohmann
-
-#endif  // CLOE_CORE_DURATION_HPP_

--- a/runtime/include/cloe/core/error.hpp
+++ b/runtime/include/cloe/core/error.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef CLOE_CORE_ERROR_HPP_
-#define CLOE_CORE_ERROR_HPP_
 
 #include <stdexcept>  // for exception
 #include <string>     // for string
@@ -90,5 +88,3 @@ class ConcludedError : public std::exception {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_CORE_ERROR_HPP_

--- a/runtime/include/cloe/core/fable.hpp
+++ b/runtime/include/cloe/core/fable.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_CORE_FABLE_HPP_
-#define CLOE_CORE_FABLE_HPP_
 
 #include <fable/fable.hpp>
 
@@ -50,5 +48,3 @@ using namespace fable::schema;  // NOLINT(build/namespaces)
 }  // namespace schema
 
 }  // namespace cloe
-
-#endif  // CLOE_CORE_FABLE_HPP_

--- a/runtime/include/cloe/core/logger.hpp
+++ b/runtime/include/cloe/core/logger.hpp
@@ -32,8 +32,6 @@
  */
 
 #pragma once
-#ifndef CLOE_CORE_LOGGER_HPP_
-#define CLOE_CORE_LOGGER_HPP_
 
 #include <functional>  // for function<>
 #include <memory>      // for shared_ptr<>
@@ -200,5 +198,3 @@ std::string to_string(LogLevel l);
 
 }  // namespace logger
 }  // namespace cloe
-
-#endif  // CLOE_CORE_LOGGER_HPP_

--- a/runtime/include/cloe/entity.hpp
+++ b/runtime/include/cloe/entity.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_ENTITY_HPP_
-#define CLOE_ENTITY_HPP_
 
 #include <string>  // for string
 
@@ -123,5 +121,3 @@ inline void to_json(Json& j, const Entity& e) {
 }
 
 }  // namespace cloe
-
-#endif  // CLOE_ENTITY_HPP_

--- a/runtime/include/cloe/handler.hpp
+++ b/runtime/include/cloe/handler.hpp
@@ -34,8 +34,6 @@
  */
 
 #pragma once
-#ifndef CLOE_HANDLER_HPP_
-#define CLOE_HANDLER_HPP_
 
 #include <functional>  // for function
 #include <map>         // for map, map<>::mapped_type
@@ -430,5 +428,3 @@ class FromConf {
 
 }  // namespace handler
 }  // namespace cloe
-
-#endif  // CLOE_HANDLER_HPP_

--- a/runtime/include/cloe/model.hpp
+++ b/runtime/include/cloe/model.hpp
@@ -47,8 +47,6 @@
  */
 
 #pragma once
-#ifndef CLOE_MODEL_HPP_
-#define CLOE_MODEL_HPP_
 
 #include <cloe/core.hpp>    // for Duration, Error, Confable
 #include <cloe/entity.hpp>  // for Entity
@@ -418,5 +416,3 @@ class ModelFactory : public Entity, public Confable {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_MODEL_HPP_

--- a/runtime/include/cloe/plugin.hpp
+++ b/runtime/include/cloe/plugin.hpp
@@ -44,8 +44,6 @@
  */
 
 #pragma once
-#ifndef CLOE_PLUGIN_HPP_
-#define CLOE_PLUGIN_HPP_
 
 #include <type_traits>  // for is_base_of, conditional<>, false_type
 
@@ -178,5 +176,3 @@ struct PluginManifest {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_PLUGIN_HPP_

--- a/runtime/include/cloe/registrar.hpp
+++ b/runtime/include/cloe/registrar.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_REGISTRAR_HPP_
-#define CLOE_REGISTRAR_HPP_
 
 #include <list>     // for list<>
 #include <memory>   // for unique_ptr<>
@@ -227,5 +225,3 @@ class Registrar {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_REGISTRAR_HPP_

--- a/runtime/include/cloe/simulator.hpp
+++ b/runtime/include/cloe/simulator.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef CLOE_SIMULATOR_HPP_
-#define CLOE_SIMULATOR_HPP_
 
 #include <memory>       // for shared_ptr<>, unique_ptr<>, make_unique<>
 #include <string>       // for string
@@ -233,5 +231,3 @@ class SimulatorFactory : public ModelFactory {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_SIMULATOR_HPP_

--- a/runtime/include/cloe/sync.hpp
+++ b/runtime/include/cloe/sync.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_SYNC_HPP_
-#define CLOE_SYNC_HPP_
 
 #include <cstdint>  // for uint64_t
 
@@ -110,5 +108,3 @@ inline void to_json(Json& j, const Sync& s) {
 }
 
 }  // namespace cloe
-
-#endif  // CLOE_SYNC_HPP_

--- a/runtime/include/cloe/trigger.hpp
+++ b/runtime/include/cloe/trigger.hpp
@@ -25,8 +25,6 @@
  */
 
 #pragma once
-#ifndef CLOE_TRIGGER_HPP_
-#define CLOE_TRIGGER_HPP_
 
 #include <memory>   // for unique_ptr<>, shared_ptr<>
 #include <string>   // for string
@@ -664,4 +662,3 @@ using ActionFactory = TriggerFactory<Action>;
 using ActionFactoryPtr = std::unique_ptr<ActionFactory>;
 
 }  // namespace cloe
-#endif  // CLOE_TRIGGER_HPP_

--- a/runtime/include/cloe/trigger/evaluate_event.hpp
+++ b/runtime/include/cloe/trigger/evaluate_event.hpp
@@ -44,8 +44,6 @@
  */
 
 #pragma once
-#ifndef CLOE_TRIGGER_EVALUATE_EVENT_HPP_
-#define CLOE_TRIGGER_EVALUATE_EVENT_HPP_
 
 #include <functional>  // for function<>
 #include <string>      // for string
@@ -82,5 +80,3 @@ using EvaluateCallback = DirectCallback<Evaluate, double>;
 
 }  // namespace events
 }  // namespace cloe
-
-#endif  // CLOE_TRIGGER_EVALUATE_EVENT_HPP_

--- a/runtime/include/cloe/trigger/example_actions.hpp
+++ b/runtime/include/cloe/trigger/example_actions.hpp
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef CLOE_TRIGGER_EXAMPLE_ACTIONS_HPP_
-#define CLOE_TRIGGER_EXAMPLE_ACTIONS_HPP_
 
 #include <memory>   // for unique_ptr<>
 #include <string>   // for string
@@ -166,5 +164,3 @@ class PushReleaseFactory : public ActionFactory {
 
 }  // namespace actions
 }  // namespace cloe
-
-#endif  // CLOE_TRIGGER_EXAMPLE_ACTIONS_HPP_

--- a/runtime/include/cloe/trigger/helper_macros.hpp
+++ b/runtime/include/cloe/trigger/helper_macros.hpp
@@ -20,10 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_TRIGGER_HELPER_MACROS_HPP_
-#define CLOE_TRIGGER_HELPER_MACROS_HPP_
 
 #define _X_FACTORY(xName) xName##Factory
 #define _X_CALLBACK(xName) xName##Callback
-
-#endif  // CLOE_TRIGGER_HELPER_MACROS_HPP_

--- a/runtime/include/cloe/trigger/nil_event.hpp
+++ b/runtime/include/cloe/trigger/nil_event.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_TRIGGER_NIL_EVENT_HPP_
-#define CLOE_TRIGGER_NIL_EVENT_HPP_
 
 #include <memory>  // for unique_ptr<>, make_unique<>
 #include <string>  // for string
@@ -81,5 +79,3 @@
   };                                                                                    \
                                                                                         \
   using _X_CALLBACK(xName) = ::cloe::DirectCallback<xName>;
-
-#endif  // CLOE_TRIGGER_NIL_EVENT_HPP_

--- a/runtime/include/cloe/trigger/set_action.hpp
+++ b/runtime/include/cloe/trigger/set_action.hpp
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef CLOE_TRIGGER_SET_ACTION_HPP_
-#define CLOE_TRIGGER_SET_ACTION_HPP_
 
 #include <memory>   // for unique_ptr<>
 #include <string>   // for string
@@ -253,5 +251,3 @@ class SetVariableActionFactory : public ActionFactory {
    private:                                                                                     \
     xDataType* ptr_;                                                                            \
   };
-
-#endif  // CLOE_TRIGGER_SET_ACTION_HPP_

--- a/runtime/include/cloe/trigger/transition_event.hpp
+++ b/runtime/include/cloe/trigger/transition_event.hpp
@@ -62,8 +62,6 @@
  */
 
 #pragma once
-#ifndef CLOE_TRIGGER_TRANSITION_EVENT_HPP_
-#define CLOE_TRIGGER_TRANSITION_EVENT_HPP_
 
 #include <string>  // for string
 
@@ -168,5 +166,3 @@ using TransitionCallback = DirectCallback<Transition<T>, T>;
 
 }  // namespace events
 }  // namespace cloe
-
-#endif  // CLOE_TRIGGER_TRANSITION_EVENT_HPP_

--- a/runtime/include/cloe/utility/command.hpp
+++ b/runtime/include/cloe/utility/command.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_COMMAND_HPP_
-#define CLOE_UTILITY_COMMAND_HPP_
 
 #include <string>  // for string
 #include <vector>  // for vector<>
@@ -182,5 +180,3 @@ ENUM_SERIALIZATION(Command::Verbosity, ({
 // clang-format on
 
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_COMMAND_HPP_

--- a/runtime/include/cloe/utility/constexpr.hpp
+++ b/runtime/include/cloe/utility/constexpr.hpp
@@ -26,13 +26,9 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_CONSTEXPR_HPP_
-#define CLOE_UTILITY_CONSTEXPR_HPP_
 
 #ifdef NDEBUG
 #define CONSTEXPR constexpr
 #else
 #define CONSTEXPR
 #endif
-
-#endif  // CLOE_UTILITY_CONSTEXPR_HPP_

--- a/runtime/include/cloe/utility/evaluate.hpp
+++ b/runtime/include/cloe/utility/evaluate.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_EVALUATE_HPP_
-#define CLOE_UTILITY_EVALUATE_HPP_
 
 #include <functional>  // for function<>
 #include <string>      // for string
@@ -46,5 +44,3 @@ std::function<bool(double)> compile_evaluation(const std::string& op, double val
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_EVALUATE_HPP_

--- a/runtime/include/cloe/utility/inja.hpp
+++ b/runtime/include/cloe/utility/inja.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_INJA_HPP_
-#define CLOE_UTILITY_INJA_HPP_
 
 #include <utility>  // for move
 
@@ -47,5 +45,3 @@ inline inja::Environment inja_env() {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_INJA_HPP_

--- a/runtime/include/cloe/utility/maybe_own.hpp
+++ b/runtime/include/cloe/utility/maybe_own.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_MAYBE_OWN_HPP_
-#define CLOE_UTILITY_MAYBE_OWN_HPP_
 
 #include <memory>
 
@@ -63,5 +61,3 @@ using maybe_own = std::unique_ptr<T, Deleter<T>>;
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_MAYBE_OWN_HPP_

--- a/runtime/include/cloe/utility/output_serializer.hpp
+++ b/runtime/include/cloe/utility/output_serializer.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_OUTPUT_SERIALIZER_HPP_
-#define CLOE_UTILITY_OUTPUT_SERIALIZER_HPP_
 
 #include <fstream>  // for ofstream
 #include <string>   // for string
@@ -225,5 +223,3 @@ class SequentialFileSerializer
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_OUTPUT_SERIALIZER_HPP_

--- a/runtime/include/cloe/utility/output_serializer_json.hpp
+++ b/runtime/include/cloe/utility/output_serializer_json.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_OUTPUT_SERIALIZER_JSON_HPP_
-#define CLOE_UTILITY_OUTPUT_SERIALIZER_JSON_HPP_
 
 #include <string>  // for string
 
@@ -136,5 +134,3 @@ std::unique_ptr<JsonFileSerializer> make_json_file_serializer(JsonFileType type,
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_OUTPUT_SERIALIZER_JSON_HPP_

--- a/runtime/include/cloe/utility/output_serializer_msgpack.hpp
+++ b/runtime/include/cloe/utility/output_serializer_msgpack.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_OUTPUT_SERIALIZER_MSGPACK_HPP_
-#define CLOE_UTILITY_OUTPUT_SERIALIZER_MSGPACK_HPP_
 
 #include <string>  // for string
 
@@ -63,5 +61,3 @@ class AbstractMsgPackSerializer : public Serializer<TSerializerArgs...> {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_OUTPUT_SERIALIZER_MSGPACK_HPP_

--- a/runtime/include/cloe/utility/resource.hpp
+++ b/runtime/include/cloe/utility/resource.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_RESOURCE_HPP_
-#define CLOE_UTILITY_RESOURCE_HPP_
 
 #include <cstddef>
 #include <string>
@@ -74,5 +72,3 @@ class Resource {
   const size_t size_;
   const char* filepath_;
 };
-
-#endif  // CLOE_UTILITY_RESOURCE_HPP_

--- a/runtime/include/cloe/utility/resource_handler.hpp
+++ b/runtime/include/cloe/utility/resource_handler.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_RESOURCE_HANDLER_HPP_
-#define CLOE_UTILITY_RESOURCE_HANDLER_HPP_
 
 #include <fstream>
 #include <string>  // for string
@@ -96,5 +94,3 @@ void to_json(cloe::Json& j, const ResourceLoader& c) {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_RESOURCE_HANDLER_HPP_

--- a/runtime/include/cloe/utility/statistics.hpp
+++ b/runtime/include/cloe/utility/statistics.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_STATISTICS_HPP_
-#define CLOE_UTILITY_STATISTICS_HPP_
 
 #include <cmath>   // for sqrt
 #include <map>     // for map<>
@@ -227,5 +225,3 @@ class Accumulator {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_STATISTICS_HPP_

--- a/runtime/include/cloe/utility/std_extensions.hpp
+++ b/runtime/include/cloe/utility/std_extensions.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_STD_EXTENSIONS_HPP_
-#define CLOE_UTILITY_STD_EXTENSIONS_HPP_
 
 #include <map>     // for map<>
 #include <string>  // for string
@@ -49,5 +47,3 @@ std::vector<std::string> map_keys(const std::map<std::string, T>& m) {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif

--- a/runtime/include/cloe/utility/tcp_transceiver.hpp
+++ b/runtime/include/cloe/utility/tcp_transceiver.hpp
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_TCP_TRANSCEIVER_HPP_
-#define CLOE_UTILITY_TCP_TRANSCEIVER_HPP_
 
 #include <chrono>   // for duration<>
 #include <memory>   // for unique_ptr<>
@@ -271,5 +269,3 @@ auto create_or_null_with(const TcpTransceiverFullConfiguration& c)
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_TCP_TRANSCEIVER_HPP_

--- a/runtime/include/cloe/utility/tcp_transceiver_config.hpp
+++ b/runtime/include/cloe/utility/tcp_transceiver_config.hpp
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_TCP_TRANSCEIVER_CONFIG_HPP_
-#define CLOE_UTILITY_TCP_TRANSCEIVER_CONFIG_HPP_
 
 #include <chrono>   // for duration
 #include <string>   // for string
@@ -117,5 +115,3 @@ struct TcpTransceiverFullConfiguration : public TcpTransceiverConfiguration {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_TCP_TRANSCEIVER_CONFIG_HPP_

--- a/runtime/include/cloe/utility/timer.hpp
+++ b/runtime/include/cloe/utility/timer.hpp
@@ -34,8 +34,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_TIMER_HPP_
-#define CLOE_UTILITY_TIMER_HPP_
 
 #include <chrono>      // for now, duration, ...
 #include <functional>  // for functional<>
@@ -101,5 +99,3 @@ class DurationTimer {
 };
 
 }  // namespace timer
-
-#endif  // CLOE_UTILITY_TIMER_HPP_

--- a/runtime/include/cloe/utility/uid_tracker.hpp
+++ b/runtime/include/cloe/utility/uid_tracker.hpp
@@ -27,8 +27,6 @@
  */
 
 #pragma once
-#ifndef CLOE_UTILITY_UID_TRACKER_HPP_
-#define CLOE_UTILITY_UID_TRACKER_HPP_
 
 #include <cassert>     // for assert
 #include <functional>  // for std::function
@@ -118,5 +116,3 @@ class UniqueIDTracker {
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_UID_TRACKER_HPP_

--- a/runtime/include/cloe/utility/xdg.hpp
+++ b/runtime/include/cloe/utility/xdg.hpp
@@ -25,8 +25,7 @@
  * Inspiration for the API of this library taken from https://github.com/goulash/xdg.
  */
 
-#ifndef CLOE_UTILITY_XDG_HPP_
-#define CLOE_UTILITY_XDG_HPP_
+#pragma once
 
 #include <functional>  // for function
 #include <string>      // for string
@@ -234,5 +233,3 @@ inline void merge_data(const boost::filesystem::path& file,
 
 }  // namespace utility
 }  // namespace cloe
-
-#endif  // CLOE_UTILITY_XDG_HPP_

--- a/runtime/include/cloe/vehicle.hpp
+++ b/runtime/include/cloe/vehicle.hpp
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef CLOE_VEHICLE_HPP_
-#define CLOE_VEHICLE_HPP_
 
 #include <cstdint>      // for uint64_t
 #include <map>          // for map<>
@@ -283,5 +281,3 @@ class Vehicle : public Model {
 };
 
 }  // namespace cloe
-
-#endif  // CLOE_VEHICLE_HPP_


### PR DESCRIPTION
Changed:
- Compiler with support for `#pragma once` now required.

This is basically every compiler on the market, so it's not a big deal, especially since several of our dependencies already require it.