### PR TITLE
Fix and refactor system tests

### DIFF
--- a/engine/tests/conanfile_with_server.py
+++ b/engine/tests/conanfile_with_server.py
@@ -7,7 +7,7 @@ from conan import ConanFile
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
 
     @property

--- a/engine/tests/conanfile_without_server.py
+++ b/engine/tests/conanfile_without_server.py
@@ -7,7 +7,7 @@ from conan import ConanFile
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
     default_options = {
         "cloe-engine:server": False,

--- a/engine/tests/test_engine.bats
+++ b/engine/tests/test_engine.bats
@@ -9,7 +9,7 @@ check_engine_with_server() {
     cloe-engine version | grep -F "server: true" &>/dev/null
 }
 
-@test "$(testname "Expect schema equality" "test_engine_json_schema.json" "4d368665-b666-4289-8a7a-b76ca53db688")" {
+@test "$(testname 'Expect schema equality' 'test_engine_json_schema.json' '4d368665-b666-4289-8a7a-b76ca53db688')" {
     # Note: you will have to update the schema files every time you change the schema,
     # in order that this test completes successfully. Here's how you do it.
     #
@@ -23,7 +23,7 @@ check_engine_with_server() {
     diff <(cloe-engine usage -j 2>/dev/null) test_engine_json_schema.json
 }
 
-@test "$(testname "Expect stack equality" "test_engine_nop_smoketest_dump.json" "3b23bb69-b249-49c8-8b4c-2fa993d8677e")" {
+@test "$(testname 'Expect stack equality' 'test_engine_nop_smoketest_dump.json' '3b23bb69-b249-49c8-8b4c-2fa993d8677e')" {
     if ! type diff &>/dev/null; then
         skip "required program diff not present"
     fi
@@ -37,21 +37,21 @@ check_engine_with_server() {
            ${reference_file}
 }
 
-@test "$(testname "Expect check success" "test_engine_smoketest.json" "20c3f11e-4a93-4066-b61e-d485be5c8979")" {
+@test "$(testname 'Expect check success' 'test_engine_smoketest.json' '20c3f11e-4a93-4066-b61e-d485be5c8979')" {
     cloe-engine check test_engine_smoketest.json
 }
 
-@test "$(testname "Expect run success" "test_engine_smoketest.json" "b590e751-dace-4139-913c-a4a812af70ac")" {
+@test "$(testname 'Expect run success' 'test_engine_smoketest.json' 'b590e751-dace-4139-913c-a4a812af70ac')" {
     cloe-engine run test_engine_smoketest.json
 }
 
-@test "$(testname "Expect check failure" "test_engine_bad_logging.json" "107c36fe-7bd9-4559-b5e9-74b72baafd9f")" {
+@test "$(testname 'Expect check failure' 'test_engine_bad_logging.json' '107c36fe-7bd9-4559-b5e9-74b72baafd9f')" {
     run cloe-engine check test_bad_logging.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect run failure" "test_engine_invalid_trigger.json" "0cf8c9e0-5538-4969-a00e-4891d7d8e647")" {
+@test "$(testname 'Expect run failure' 'test_engine_invalid_trigger.json' '0cf8c9e0-5538-4969-a00e-4891d7d8e647')" {
     # Currently, cloe-engine cannot tell before starting a simulation
     # whether the triggers exist or not.
     cloe-engine check test_engine_invalid_trigger.json
@@ -66,11 +66,11 @@ check_engine_with_server() {
     cloe-engine run test_engine_optional_trigger.json
 }
 
-@test "$(testname "Expect check success" "test_engine_curl_succeed.json" "5eff0c85-77f1-4792-9987-e46a36617d99")" {
+@test "$(testname 'Expect check success' 'test_engine_curl_succeed.json' '5eff0c85-77f1-4792-9987-e46a36617d99')" {
     cloe-engine check test_engine_curl_succeed.json
 }
 
-@test "$(testname "Expect run success" "test_engine_curl_succeed.json" "f473cb96-7f2e-4ac1-801a-fd93343f6e24")" {
+@test "$(testname 'Expect run success' 'test_engine_curl_succeed.json' 'f473cb96-7f2e-4ac1-801a-fd93343f6e24')" {
     if ! type curl &>/dev/null; then
         skip "required program curl not present"
     fi
@@ -80,7 +80,7 @@ check_engine_with_server() {
     cloe-engine run test_engine_curl_succeed.json
 }
 
-@test "$(testname "Expect run failure" "test_engine_curl_succeed.json" "7aa4b455-ad74-4e5f-bf82-43761d7cd81b")" {
+@test "$(testname 'Expect run failure' 'test_engine_curl_succeed.json' '7aa4b455-ad74-4e5f-bf82-43761d7cd81b')" {
     # When disabling the `enable_command_action` flag, curl
     # should not be used and the simulation should fail by default.
     run cloe-engine run test_engine_curl_succeed.json \
@@ -88,99 +88,99 @@ check_engine_with_server() {
     test $status -eq $CLOE_EXIT_FAILURE
 }
 
-@test "$(testname "Expect check failure" "test_engine_empty.json" "d04369fb-e4af-4f80-aaa8-8352d3dec42e")" {
+@test "$(testname 'Expect check failure' 'test_engine_empty.json' 'd04369fb-e4af-4f80-aaa8-8352d3dec42e')" {
     run cloe-engine check test_engine_empty.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
     test $(echo $output 2>&1 | wc -l) -lt 32
 }
 
-@test "$(testname "Expect check failure" "test_engine_version_absent.json" "4de20aed-2a8f-442b-bdb3-1da76237ee1e")" {
+@test "$(testname 'Expect check failure' 'test_engine_version_absent.json' '4de20aed-2a8f-442b-bdb3-1da76237ee1e')" {
     run cloe-engine check test_engine_version_absent.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
     test $(echo $output 2>&1 | wc -l) -lt 32
 }
 
-@test "$(testname "Expect check failure" "test_engine_version_wrong.json" "2c883a3d-b877-4fca-88a1-8078208f0d2b")" {
+@test "$(testname 'Expect check failure' 'test_engine_version_wrong.json' '2c883a3d-b877-4fca-88a1-8078208f0d2b')" {
     run cloe-engine check test_engine_version_wrong.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
     test $(echo $output 2>&1 | wc -l) -lt 32
 }
 
-@test "$(testname "Expect check success" "test_engine_fail_trigger.json" "cd540e21-63e9-421f-8e7b-e113339253a2")" {
+@test "$(testname 'Expect check success' 'test_engine_fail_trigger.json' 'cd540e21-63e9-421f-8e7b-e113339253a2')" {
     cloe-engine check test_engine_fail_trigger.json
 }
 
-@test "$(testname "Expect run failure" "test_engine_fail_trigger.json" "c9bc16de-4902-4abf-90ac-d4bef0d0b26e")" {
+@test "$(testname 'Expect run failure' 'test_engine_fail_trigger.json' 'c9bc16de-4902-4abf-90ac-d4bef0d0b26e')" {
     run cloe-engine run test_engine_fail_trigger.json
     assert_exit_failure $status
     test $status -eq $CLOE_EXIT_FAILURE
     echo "$output" | grep '"outcome": "failure"'
 }
 
-@test "$(testname "Expect check failure" "test_engine_hook_invalid.json" "cc3d8879-5ca5-4ffb-a78e-c9723ac82b91")" {
+@test "$(testname 'Expect check failure' 'test_engine_hook_invalid.json' 'cc3d8879-5ca5-4ffb-a78e-c9723ac82b91')" {
     run cloe-engine check test_engine_hook_invalid.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check failure" "test_engine_hook_noexec.json" "3f35bb1f-307a-42e3-a2ea-739e60cab084")" {
+@test "$(testname 'Expect check failure' 'test_engine_hook_noexec.json' '3f35bb1f-307a-42e3-a2ea-739e60cab084')" {
     run cloe-engine check test_engine_hook_noexec.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check success" "test_engine_hook_failure.json" "d6d8fe35-c513-4e43-8984-e9da0958c0fd")" {
+@test "$(testname 'Expect check success' 'test_engine_hook_failure.json' 'd6d8fe35-c513-4e43-8984-e9da0958c0fd')" {
     cloe-engine check test_engine_hook_failure.json
 }
 
-@test "$(testname "Expect run failure" "test_engine_hook_failure.json" "798ee383-667d-4971-af2f-51c49c47b750")" {
+@test "$(testname 'Expect run failure' 'test_engine_hook_failure.json' '798ee383-667d-4971-af2f-51c49c47b750')" {
     run cloe-engine run test_engine_hook_failure.json
     test $status -eq $CLOE_EXIT_ABORTED
 }
 
-@test "$(testname "Expect check success" "test_engine_hook_ok.json" "2e3064bf-0e6d-4934-b25f-78cae54bd4d1")" {
+@test "$(testname 'Expect check success' 'test_engine_hook_ok.json' '2e3064bf-0e6d-4934-b25f-78cae54bd4d1')" {
     cloe-engine check test_engine_hook_ok.json
 }
 
-@test "$(testname "Expect run success" "test_engine_hook_ok.json" "303afa7e-3ebe-4db3-a802-84b2cdba97c5")" {
+@test "$(testname 'Expect run success' 'test_engine_hook_ok.json' '303afa7e-3ebe-4db3-a802-84b2cdba97c5')" {
     cloe-engine run test_engine_hook_ok.json
 }
 
-@test "$(testname "Expect check success" "test_engine_ignore.json" "78a470a4-cbe1-4436-a43f-d956685b8bc9")" {
+@test "$(testname 'Expect check success' 'test_engine_ignore.json' '78a470a4-cbe1-4436-a43f-d956685b8bc9')" {
     cloe-engine check test_engine_ignore.json
 }
 
-@test "$(testname "Expect run success" "test_engine_ignore.json" "1738bf42-3784-4e9c-b4d4-76e94c8e5271")" {
+@test "$(testname 'Expect run success' 'test_engine_ignore.json' '1738bf42-3784-4e9c-b4d4-76e94c8e5271')" {
     cloe-engine run test_engine_ignore.json
 }
 
-@test "$(testname "Expect check failure" "test_engine_include_nonexistent.json" "bad115cc-0397-48e6-9a51-bdcfeaf6b024")" {
+@test "$(testname 'Expect check failure' 'test_engine_include_nonexistent.json' 'bad115cc-0397-48e6-9a51-bdcfeaf6b024')" {
     run cloe-engine check test_engine_include_nonexistent.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check failure" "test_engine_include_self.json" "7b3e4010-19a0-4518-b8d7-00655af93755")" {
+@test "$(testname 'Expect check failure' 'test_engine_include_self.json' '7b3e4010-19a0-4518-b8d7-00655af93755')" {
     run cloe-engine check test_engine_include_self.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check failure" "test_engine_incomplete.json" "8baa711a-9279-4527-9ecc-6b685551a45f")" {
+@test "$(testname 'Expect check failure' 'test_engine_incomplete.json' '8baa711a-9279-4527-9ecc-6b685551a45f')" {
     run cloe-engine check test_engine_incomplete.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect run failure" "test_engine_incomplete.json" "75a0c642-2373-4d6d-bd40-61e0f7840c57")" {
+@test "$(testname 'Expect run failure' 'test_engine_incomplete.json' '75a0c642-2373-4d6d-bd40-61e0f7840c57')" {
     run cloe-engine run test_engine_incomplete.json
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check success" "test_engine_keep_alive.json" "254544dc-c17a-4a5c-8685-723ed1c758cf")" {
+@test "$(testname 'Expect check success' 'test_engine_keep_alive.json' '254544dc-c17a-4a5c-8685-723ed1c758cf')" {
     if ! type kill &>/dev/null; then
         skip "required program kill not present"
     fi
@@ -188,7 +188,7 @@ check_engine_with_server() {
     cloe-engine check test_engine_keep_alive.json
 }
 
-@test "$(testname "Expect run success" "test_engine_keep_alive.json" "0c5ace05-f5ca-4615-9c14-62a75b69651a")" {
+@test "$(testname 'Expect run success' 'test_engine_keep_alive.json' '0c5ace05-f5ca-4615-9c14-62a75b69651a')" {
     if ! type kill &>/dev/null; then
         skip "required program kill not present"
     fi
@@ -196,53 +196,53 @@ check_engine_with_server() {
     cloe-engine run test_engine_keep_alive.json
 }
 
-@test "$(testname "Expect check success" "test_engine_namespaced_smoketest.json" "c9d4f8d3-aec7-404e-95f5-7a14cd8674c7")" {
+@test "$(testname 'Expect check success' 'test_engine_namespaced_smoketest.json' 'c9d4f8d3-aec7-404e-95f5-7a14cd8674c7')" {
     cloe-engine check test_engine_namespaced_smoketest.json
 }
 
-@test "$(testname "Expect run success" "test_engine_namespaced_smoketest.json" "c2fd481b-f135-4fb5-86f0-699af0f93497")" {
+@test "$(testname 'Expect run success' 'test_engine_namespaced_smoketest.json' 'c2fd481b-f135-4fb5-86f0-699af0f93497')" {
     cloe-engine run test_engine_namespaced_smoketest.json
 }
 
-@test "$(testname "Expect check failure" "test_engine_no_binding.json" "111a4f1f-7679-48a8-88de-a6773dab055e")" {
+@test "$(testname 'Expect check failure' 'test_engine_no_binding.json' '111a4f1f-7679-48a8-88de-a6773dab055e')" {
     run cloe-engine check test_engine_no_binding.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect run failure" "test_engine_no_binding.json" "dc682e38-38e5-43d7-8989-b477cb0f6c2a")" {
+@test "$(testname 'Expect run failure' 'test_engine_no_binding.json' 'dc682e38-38e5-43d7-8989-b477cb0f6c2a')" {
     run cloe-engine run test_engine_no_binding.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check failure" "test_engine_no_vehicle.json" "319a342a-88d2-4b07-a4de-1fef78b13d72")" {
+@test "$(testname 'Expect check failure' 'test_engine_no_vehicle.json' '319a342a-88d2-4b07-a4de-1fef78b13d72')" {
     run cloe-engine check test_engine_no_vehicle.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect run failure" "test_engine_no_vehicle.json" "4b4fcd8b-add1-451c-ad7b-9c0a3efb6525")" {
+@test "$(testname 'Expect run failure' 'test_engine_no_vehicle.json' '4b4fcd8b-add1-451c-ad7b-9c0a3efb6525')" {
     run cloe-engine run test_engine_no_vehicle.json
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check failure" "test_engine_unknown_vehicle.json" "3f754bea-4806-4f43-9c60-a78b13b43f6f")" {
+@test "$(testname 'Expect check failure' 'test_engine_unknown_vehicle.json' '3f754bea-4806-4f43-9c60-a78b13b43f6f')" {
     run cloe-engine check test_engine_unknown_vehicle.json
     assert_check_failure $status $output
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect run failure" "test_engine_unknown_vehicle.json" "da3d7c55-6024-481b-bee4-32233df6c330")" {
+@test "$(testname 'Expect run failure' 'test_engine_unknown_vehicle.json' 'da3d7c55-6024-481b-bee4-32233df6c330')" {
     run cloe-engine run test_engine_unknown_vehicle.json
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check success" "test_engine_pause.json" "24528c78-f681-44ff-8b9c-5c172acf19b9")" {
+@test "$(testname 'Expect check success' 'test_engine_pause.json' '24528c78-f681-44ff-8b9c-5c172acf19b9')" {
     cloe-engine check test_engine_pause.json
 }
 
-@test "$(testname "Expect run success" "test_engine_pause.json" "845e3c9b-2a6d-469a-93a7-67fe9531c81e")" {
+@test "$(testname 'Expect run success' 'test_engine_pause.json' '845e3c9b-2a6d-469a-93a7-67fe9531c81e')" {
     if ! type curl &>/dev/null; then
         skip "required program curl not present"
     fi
@@ -253,38 +253,38 @@ check_engine_with_server() {
     cloe-engine run test_engine_pause.json
 }
 
-@test "$(testname "Expect check success" "test_engine_sticky_trigger.json" "76400941-50f5-4185-9107-335005079569")" {
+@test "$(testname 'Expect check success' 'test_engine_sticky_trigger.json' '76400941-50f5-4185-9107-335005079569')" {
     cloe-engine check test_engine_sticky_trigger.json
 }
 
-@test "$(testname "Expect run success" "test_engine_sticky_trigger.json" "dcfbdd81-8bb0-4de3-ac68-486aa5a9ce66")" {
+@test "$(testname 'Expect run success' 'test_engine_sticky_trigger.json' 'dcfbdd81-8bb0-4de3-ac68-486aa5a9ce66')" {
     skip "not implemented yet"
     cloe-engine run test_engine_sticky_trigger.json
 }
 
-@test "$(testname "Expect check success" "test_engine_stuck_controller.json" "72f151f7-26c3-4a79-a0ec-8b0d4e678442")" {
+@test "$(testname 'Expect check success' 'test_engine_stuck_controller.json' '72f151f7-26c3-4a79-a0ec-8b0d4e678442')" {
     cloe-engine check test_engine_stuck_controller.json
 }
 
-@test "$(testname "Expect run aborted" "test_engine_stuck_controller.json" "13a244da-f18e-4dec-af5c-d5dcb4c2cd36")" {
+@test "$(testname 'Expect run aborted' 'test_engine_stuck_controller.json' '13a244da-f18e-4dec-af5c-d5dcb4c2cd36')" {
     run cloe-engine run test_engine_stuck_controller.json
     assert_exit_failure $status
     echo "$output" | grep '"outcome": "aborted"'
 }
 
-@test "$(testname "Expect check success" "test_engine_stuck_controller_continue.json" "19b3d407-c980-4507-9bd2-9d6dca5e1320")" {
+@test "$(testname 'Expect check success' 'test_engine_stuck_controller_continue.json' '19b3d407-c980-4507-9bd2-9d6dca5e1320')" {
     cloe-engine check test_engine_stuck_controller_continue.json
 }
 
-@test "$(testname "Expect run success" "test_engine_stuck_controller_continue.json" "5692f85d-87a2-4866-9875-647802ce1d62")" {
+@test "$(testname 'Expect run success' 'test_engine_stuck_controller_continue.json' '5692f85d-87a2-4866-9875-647802ce1d62')" {
     cloe-engine run test_engine_stuck_controller_continue.json
 }
 
-@test "$(testname "Expect check success" "test_engine_watchdog.json" "30e097cf-6e51-484b-a212-690769cd4c91")" {
+@test "$(testname 'Expect check success' 'test_engine_watchdog.json' '30e097cf-6e51-484b-a212-690769cd4c91')" {
     cloe-engine check test_engine_watchdog.json
 }
 
-@test "$(testname "Expect run syskill" "test_engine_watchdog.json" "058ff9b7-98dc-4583-8e80-c70e9c5e1f4e")" {
+@test "$(testname 'Expect run syskill' 'test_engine_watchdog.json' '058ff9b7-98dc-4583-8e80-c70e9c5e1f4e')" {
     if ! type curl &>/dev/null; then
         skip "required program curl not present"
     fi
@@ -299,13 +299,13 @@ check_engine_with_server() {
     test $status -eq $CLOE_EXIT_SYSKILL
 }
 
-@test "$(testname "Expect check/run success" "test_engine_smoketest.json [ts=5ms]" "1a31022c-e20c-4a9e-9373-ad54a3729442")" {
+@test "$(testname 'Expect check/run success' 'test_engine_smoketest.json [ts=5ms]' '1a31022c-e20c-4a9e-9373-ad54a3729442')" {
     local timestep_stack="${CLOE_ROOT}/tests/option_timestep_5.json"
     cloe-engine check test_engine_smoketest.json "${timestep_stack}"
     cloe-engine run test_engine_smoketest.json "${timestep_stack}"
 }
 
-@test "$(testname "Expect check/run success" "test_engine_smoketest.json [ts=60ms]" "e7957fa0-1145-4458-b665-eec51c1f0da5")" {
+@test "$(testname 'Expect check/run success' 'test_engine_smoketest.json [ts=60ms]' 'e7957fa0-1145-4458-b665-eec51c1f0da5')" {
     local timestep_stack="${CLOE_ROOT}/tests/option_timestep_60.json"
     cloe-engine check test_engine_smoketest.json "${timestep_stack}"
     cloe-engine run test_engine_smoketest.json "${timestep_stack}"

--- a/engine/tests/test_engine_replica_smoketest.bats
+++ b/engine/tests/test_engine_replica_smoketest.bats
@@ -14,7 +14,7 @@ teardown() {
     rm -r "${CLOE_TMP_REGISTRY}" || true
 }
 
-@test "$(testname "Expect exact replication" "test_engine_replica_smoketest.json" "f4fa1794-cc78-4ae6-aa5e-6a3ed3c7913c")" {
+@test "$(testname 'Expect exact replication' 'test_engine_replica_smoketest.json' 'f4fa1794-cc78-4ae6-aa5e-6a3ed3c7913c')" {
     # Clean up in case temporary registry already exists.
     if [[ -d "$CLOE_TMP_REGISTRY" ]]; then
         rm -r "$CLOE_TMP_REGISTRY" || true

--- a/optional/vtd/tests/conanfile_with_vtd-2.2.0.py
+++ b/optional/vtd/tests/conanfile_with_vtd-2.2.0.py
@@ -8,7 +8,7 @@ from conan import ConanFile, tools
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
 
     default_options = {

--- a/optional/vtd/tests/conanfile_with_vtd-2022.3.py
+++ b/optional/vtd/tests/conanfile_with_vtd-2022.3.py
@@ -8,7 +8,7 @@ from conan.tools import scm
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
 
     default_options = {

--- a/optional/vtd/tests/test_vtd.bats
+++ b/optional/vtd/tests/test_vtd.bats
@@ -12,7 +12,7 @@ teardown() {
     "${VTD_LAUNCH}" stop
 }
 
-@test "$(testname "Expect check/run success" "test_vtd_smoketest.json" "515fa80c-fb35-48f3-840e-7825c6443c92")" {
+@test "$(testname 'Expect check/run success' 'test_vtd_smoketest.json' '515fa80c-fb35-48f3-840e-7825c6443c92')" {
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
     fi
@@ -20,7 +20,7 @@ teardown() {
     cloe-engine run test_vtd_smoketest.json
 }
 
-@test "$(testname "Expect check/run success" "test_vtd_scp_action.json" "3d1ec074-8f64-460c-8d2f-57ffc30d793c")" {
+@test "$(testname 'Expect check/run success' 'test_vtd_scp_action.json' '3d1ec074-8f64-460c-8d2f-57ffc30d793c')" {
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
     fi
@@ -29,7 +29,7 @@ teardown() {
     test $status -eq $CLOE_EXIT_STOPPED
 }
 
-@test "$(testname "Expect check/run success" "test_vtd_api_recording.json" "71eaf779-2aa7-492b-83b5-27504ae92f9e")" {
+@test "$(testname 'Expect check/run success' 'test_vtd_api_recording.json' '71eaf779-2aa7-492b-83b5-27504ae92f9e')" {
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
     fi
@@ -41,7 +41,7 @@ teardown() {
     rm -r "${CLOE_TMP_REGISTRY}" || true
 }
 
-@test "$(testname "Expect check/run success" "test_vtd_watchdog.json" "b3d51d61-2778-4fd4-b9ea-7711d1913395")" {
+@test "$(testname 'Expect check/run success' 'test_vtd_watchdog.json' 'b3d51d61-2778-4fd4-b9ea-7711d1913395')" {
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
     fi
@@ -56,7 +56,7 @@ teardown() {
     test $status -eq $CLOE_EXIT_SYSKILL
 }
 
-@test "$(testname "Expect check/run success" "test_vtd_smoketest.json [ts=5ms]" "58f1411a-6f78-49af-832b-d7c884639ef7")" {
+@test "$(testname 'Expect check/run success' 'test_vtd_smoketest.json [ts=5ms]' '58f1411a-6f78-49af-832b-d7c884639ef7')" {
     local timestep_stack="option_timestep_5.json"
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
@@ -65,7 +65,7 @@ teardown() {
     cloe-engine run test_vtd_smoketest.json "${timestep_stack}"
 }
 
-@test "$(testname "Expect check/run success" "test_vtd_smoketest.json [ts=60ms]" "4f9173c0-00df-49d9-b164-22f2996a5520")" {
+@test "$(testname 'Expect check/run success' 'test_vtd_smoketest.json [ts=60ms]' '4f9173c0-00df-49d9-b164-22f2996a5520')" {
     local timestep_stack="option_timestep_60.json"
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
@@ -74,7 +74,7 @@ teardown() {
     cloe-engine run test_vtd_smoketest.json "${timestep_stack}"
 }
 
-@test "$(testname "Expect run success" "test_vtd_clean_timeout.json" "15439b9f-ac01-4e0b-b981-60064194880a")" {
+@test "$(testname 'Expect run success' 'test_vtd_clean_timeout.json' '15439b9f-ac01-4e0b-b981-60064194880a')" {
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
     fi
@@ -91,7 +91,7 @@ teardown() {
 # vehicles in VTD: https://redmine.vires.com/issues/13340
 #
 # TODO: Improve the tested condition once we now how to correctly deal with VTD
-@test "$(testname "Expect check/run success" "test_vtd_multi_agent_smoketest.json" "572ef7cf-67b2-47fd-849f-55339063208a")" {
+@test "$(testname 'Expect check/run success' 'test_vtd_multi_agent_smoketest.json' '572ef7cf-67b2-47fd-849f-55339063208a')" {
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
     fi
@@ -99,7 +99,7 @@ teardown() {
     cloe-engine run test_vtd_multi_agent_smoketest.json
 }
 
-@test "$(testname "Expect run failure" "test_vtd_unknown_sensor.json" "ed9411da-d789-456d-9eb3-9cff63144775")" {
+@test "$(testname 'Expect run failure' 'test_vtd_unknown_sensor.json' 'ed9411da-d789-456d-9eb3-9cff63144775')" {
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
     fi
@@ -108,7 +108,7 @@ teardown() {
     test $status -eq $CLOE_EXIT_UNKNOWN
 }
 
-@test "$(testname "Expect check/run success" "test_gndtruth_smoketest.json" "2554c4a8-297c-4d74-8944-44b67aa756a5")" {
+@test "$(testname 'Expect check/run success' 'test_gndtruth_smoketest.json' '2554c4a8-297c-4d74-8944-44b67aa756a5')" {
     if ! test_plugin_exists gndtruth_extractor; then
         skip "required controller gndtruth_extractor not present"
     elif ! test_vtd_plugin_exists; then
@@ -144,7 +144,7 @@ test_vtd_osi_model_exists() {
     cloe_shell -c 'test -n "$(echo "${VTD_EXTERNAL_MODELS}" | grep -o "OSMPDummySensor.so")"'
 }
 
-@test "$(testname "Expect check/run success" "test_vtd_smoketest_osi.json" "12b79a10-126c-4e21-8ebd-69f458651dd9")" {
+@test "$(testname 'Expect check/run success' 'test_vtd_smoketest_osi.json' '12b79a10-126c-4e21-8ebd-69f458651dd9')" {
     if ! test_vtd_plugin_exists; then
         skip "required simulator vtd not present"
     fi

--- a/plugins/gndtruth_extractor/tests/conanfile_default.py
+++ b/plugins/gndtruth_extractor/tests/conanfile_default.py
@@ -3,7 +3,7 @@ from conan import ConanFile
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
 
     default_options = {

--- a/plugins/minimator/tests/conanfile_default.py
+++ b/plugins/minimator/tests/conanfile_default.py
@@ -7,7 +7,7 @@ from conan import ConanFile
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
 
     default_options = {

--- a/plugins/minimator/tests/test_minimator.bats
+++ b/plugins/minimator/tests/test_minimator.bats
@@ -5,27 +5,27 @@ export CLOE_ROOT="${BATS_TEST_DIRNAME}/../../.."
 load "${CLOE_ROOT}/tests/setup_bats.bash"
 load "${CLOE_ROOT}/tests/setup_testname.bash"
 
-@test "$(testname "Expect check success" "test_minimator_smoketest.json" "c7a427e7-eb2b-4ae7-85ec-a35b7540d4aa")" {
+@test "$(testname 'Expect check success' 'test_minimator_smoketest.json' 'c7a427e7-eb2b-4ae7-85ec-a35b7540d4aa')" {
     cloe-engine check test_minimator_smoketest.json
 }
 
-@test "$(testname "Expect run success" "test_minimator_smoketest.json" "7c67ceb9-3d1d-47e4-9342-0b39099c59d6")" {
+@test "$(testname 'Expect run success' 'test_minimator_smoketest.json' '7c67ceb9-3d1d-47e4-9342-0b39099c59d6')" {
     cloe-engine run test_minimator_smoketest.json
 }
 
-@test "$(testname "Expect check/run success" "test_minimator_smoketest.json [ts=5ms]" "57254185-5480-4859-b2a5-6c3a211a22e0")" {
+@test "$(testname 'Expect check/run success' 'test_minimator_smoketest.json [ts=5ms]' '57254185-5480-4859-b2a5-6c3a211a22e0')" {
     local timestep_stack="${CLOE_ROOT}/tests/option_timestep_5.json"
     cloe-engine check test_minimator_smoketest.json "${timestep_stack}"
     cloe-engine run test_minimator_smoketest.json "${timestep_stack}"
 }
 
-@test "$(testname "Expect check/run success" "test_minimator_smoketest.json [ts=60ms]" "a0d4982f-8c02-4759-bc88-cc30a1ccbbf0")" {
+@test "$(testname 'Expect check/run success' 'test_minimator_smoketest.json [ts=60ms]' 'a0d4982f-8c02-4759-bc88-cc30a1ccbbf0')" {
     local timestep_stack="${CLOE_ROOT}/tests/option_timestep_60.json"
     cloe-engine check test_minimator_smoketest.json "${timestep_stack}"
     cloe-engine run test_minimator_smoketest.json "${timestep_stack}"
 }
 
-@test "$(testname "Expect check/run success" "test_minimator_multi_agent_smoketest.json" "90e440ec-e8bc-40bb-8d2a-de224ee872bb")" {
+@test "$(testname 'Expect check/run success' 'test_minimator_multi_agent_smoketest.json' '90e440ec-e8bc-40bb-8d2a-de224ee872bb')" {
     cloe-engine check test_minimator_multi_agent_smoketest.json
     cloe-engine run test_minimator_multi_agent_smoketest.json
 }

--- a/plugins/virtue/tests/conanfile_default.py
+++ b/plugins/virtue/tests/conanfile_default.py
@@ -7,7 +7,7 @@ from conan import ConanFile
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
 
     default_options = {

--- a/plugins/virtue/tests/test_virtue.bats
+++ b/plugins/virtue/tests/test_virtue.bats
@@ -5,20 +5,20 @@ export CLOE_ROOT="${BATS_TEST_DIRNAME}/../../.."
 load "${CLOE_ROOT}/tests/setup_bats.bash"
 load "${CLOE_ROOT}/tests/setup_testname.bash"
 
-@test "$(testname "Expect check success" "test_virtue_missing_lanes_fail.json" "d9072cc3-62f3-4f11-bf9e-b514fea67e4b")" {
+@test "$(testname 'Expect check success' 'test_virtue_missing_lanes_fail.json' 'd9072cc3-62f3-4f11-bf9e-b514fea67e4b')" {
     cloe-engine check test_virtue_missing_lanes_fail.json
 }
 
 # shall fail because nop simulator provides no lanes
-@test "$(testname "Expect run failure" "test_virtue_missing_lanes_fail.json" "661c7f7b-32b5-4609-9caa-930b956596d3")" {
+@test "$(testname 'Expect run failure' 'test_virtue_missing_lanes_fail.json' '661c7f7b-32b5-4609-9caa-930b956596d3')" {
     ! cloe-engine run test_virtue_missing_lanes_fail.json
 }
 
-@test "$(testname "Expect check success" "test_virtue_missing_lanes_pass.json" "96aeec09-b5de-4a1e-8a29-a481315c0735")" {
+@test "$(testname 'Expect check success' 'test_virtue_missing_lanes_pass.json' '96aeec09-b5de-4a1e-8a29-a481315c0735')" {
     cloe-engine check test_virtue_missing_lanes_pass.json
 }
 
 # shall pass because minimator provides lanes
-@test "$(testname "Expect run success" "test_virtue_missing_lanes_pass.json" "745efe30-621e-4231-8a8f-7da6a833a881")" {
+@test "$(testname 'Expect run success' 'test_virtue_missing_lanes_pass.json' '745efe30-621e-4231-8a8f-7da6a833a881')" {
     cloe-engine run test_virtue_missing_lanes_pass.json
 }

--- a/tests/conanfile_default.py
+++ b/tests/conanfile_default.py
@@ -7,7 +7,7 @@ from conan import ConanFile
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
 
     default_options = {

--- a/tests/conanfile_with_boost_1.78.py
+++ b/tests/conanfile_with_boost_1.78.py
@@ -7,7 +7,7 @@ from conan import ConanFile
 
 
 class CloeTest(ConanFile):
-    python_requires = "cloe-launch-profile/[~=0.20.0]@cloe/develop"
+    python_requires = "cloe-launch-profile/[>=0.20.0]@cloe/develop"
     python_requires_extend = "cloe-launch-profile.Base"
 
     default_options = {

--- a/tests/test_all_plugin_usages.bats
+++ b/tests/test_all_plugin_usages.bats
@@ -11,6 +11,7 @@ setup() {
     IFS="${OLDIFS}"
     cloe_plugins=()
     for path in ${plugin_path[@]}; do
+        shopt -s nullglob
         cloe_plugins+=(${path}/*.so)
     done
     cloe_plugins+=("builtin://simulator/nop" "builtin://controller/nop")

--- a/tests/test_all_plugin_usages.bats
+++ b/tests/test_all_plugin_usages.bats
@@ -17,7 +17,7 @@ setup() {
     export cloe_plugins
 }
 
-@test "$(testname "Expect run success" "cloe-engine usage" "93c5a785-8f07-4df2-92ee-6d47e728f201")" {
+@test "$(testname 'Expect run success' 'cloe-engine usage' '93c5a785-8f07-4df2-92ee-6d47e728f201')" {
     for file in "${cloe_plugins[@]}"; do
         echo "Checking: $file"
         run cloe-engine usage $file
@@ -29,7 +29,7 @@ setup() {
     done
 }
 
-@test "$(testname "Expect run success" "cloe-engine usage -j" "7576ad69-1d16-43f8-9809-af0bf408e4f1")" {
+@test "$(testname 'Expect run success' 'cloe-engine usage -j' '7576ad69-1d16-43f8-9809-af0bf408e4f1')" {
     if ! type jq &>/dev/null; then
         skip "required program jq not present"
     fi


### PR DESCRIPTION
Fix:
- Test configurations depend on any compatible version of `cloe-launch-profile`
- Don't fail test when `*.so` glob does not match anything

Refactor:
- Nest `'` quotes inside `"` in test definitions instead of nesting `"` inside `"`.
  Yes, it works, but it makes working with it more difficult than it needs to be.