### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ this shouldn't need to be performed manually.
 
 See the documentation on testing Cloe for more details.
 
+### Disabling Unit Tests
+
+You can disable running unit tests by setting `CONAN_RUN_TESTS=0`,
+as documented in the [Conan Manual](https://docs.conan.io/1/reference/env_vars.html#conan-run-tests).
+
+Alternatively, you can also prevent the unit tests from being built
+in the first place, by setting `tools.build:skip_test=1` in the
+Conan configuration, as documented
+[here](https://docs.conan.io/1/reference/config_files/global_conf.html?highlight=skip_test)
+and [here](https://docs.conan.io/1/reference/conanfile/tools/cmake/cmaketoolchain.html?highlight=skip_test).
+
+When using `make` to build the project, add this to the command line:
+
+    CONAN_OPTIONS="-c tools.build:skip_test=1"
+
+
 ### Building Docker Images
 
 The `Dockerfile` provided in the repository root can be used to create one

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "Eclipse Cloe"
-copyright = "2022 Eclipse Cloe Contributors"
+copyright = "2023 Eclipse Cloe Contributors"
 author = "Cloe Team"
 
 # The short X.Y version
@@ -50,6 +50,14 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_inline_tabs",
     "myst_parser",
+]
+
+myst_enable_extensions = [
+    "colon_fence",
+    "tasklist",
+    "fieldlist",
+    "deflist",
+    "attrs_block",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -43,7 +43,6 @@ certainly require some changes before accepting.
    :maxdepth: 2
 
    contributing/creating-a-new-release
-   contributing/adding-a-new-action
    contributing/recording-with-asciinema
 
    contributing/git-guidelines

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -21,5 +21,6 @@ For standard installation instructions please refer to the :doc:`installation gu
    develop/new-controller
    develop/integrating-a-controller
    develop/debugging-a-controller
+   develop/adding-a-new-action
 
    develop/cloe-ui

--- a/docs/develop/adding-a-new-action.rst
+++ b/docs/develop/adding-a-new-action.rst
@@ -39,8 +39,9 @@ Then we come to the source for the ``Log`` action:
      Log(const std::string& name, LogLevel level, const std::string& msg)
          : Action(name), level_(level), msg_(msg) {}
      ActionPtr clone() const override { return std::make_unique<Log>(name(), level_, msg_); }
-     void operator()(const Sync&, TriggerRegistrar&) override {
+     CallbackResult operator()(const Sync&, TriggerRegistrar&) override {
        logger()->log(level_, msg_.c_str());
+       return CallbackResult::Ok;
      }
      bool is_significant() const override { return false; }
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -21,6 +21,12 @@ background knowledge for any of the following topics.
    a Cloe stack file. These configure the runtime and the orchestration of
    a simulation.
 
+:doc:`reference/hooks`
+   provides an explanation of how to use pre-connect and post-disconnect hooks.
+
+:doc:`reference/variables`
+   provides an explanation of variable interpolation in input stack files.
+
 :doc:`reference/watchdog`
    provides a detailed explanation of the watchdog feature of the Cloe runtime.
 
@@ -48,6 +54,8 @@ background knowledge for any of the following topics.
    reference/system-states
    reference/model-states
    reference/config
+   reference/hooks
+   reference/variables
    reference/watchdog
    reference/json-api
    reference/triggers

--- a/docs/reference/actions.rst
+++ b/docs/reference/actions.rst
@@ -195,11 +195,26 @@ command
 """""""
 Run arbitrary system commands as interpreted by the ``/bin/sh`` shell.
 
-==============  ==========  ==============  ==================================
-Parameter       Required    Type            Description
-==============  ==========  ==============  ==================================
-``command``     yes         string          command to execute in shell
-==============  ==========  ==============  ==================================
+==================  ==========  ==============  ==================================
+Parameter           Required    Type            Description
+==================  ==========  ==============  ==================================
+``command``         yes         string          command to execute in shell
+``mode``            no          string          one of ``sync``, ``async``, ``detach``
+``output``          no          string          one of ``never``, ``normal``, ``always``
+``ignore_failure``  no          bool            whether to ignore execution failure
+==================  ==========  ==============  ==================================
+
+And the alternative is:
+
+==================  ==========  ==============  ==================================
+Parameter           Required    Type            Description
+==================  ==========  ==============  ==================================
+``path``            yes         string          command to execute directly
+``args``            no          array           arguments to pass to path
+``mode``            no          string          one of ``sync``, ``async``, ``detach``
+``output``          no          string          one of ``never``, ``normal``, ``always``
+``ignore_failure``  no          bool            whether to ignore execution failure
+==================  ==========  ==============  ==================================
 
 Inline short-form is supported as the content of ``command``.
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -1,0 +1,56 @@
+Hook Execution
+==============
+
+When running simulations, you may want to run programs before or after the
+simulation execution itself. Triggers currently only offer events during
+a simulation, since many actions are only available after simulation agents are
+connected and the simulation has started.
+
+The Cloe engine can execute hooks at two different times:
+
+- pre-connect
+- post-disconnect
+
+These can be used in the ``engine`` section of the stack file:
+
+- ``/engine/hooks/pre_connect`` as an array of command actions
+- ``/engine/hooks/post_disconnect`` as an array of command actions
+
+For a description of the ``command`` action, see :doc:`actions`.
+
+Here is an example bootstrap stack file, which is included in the list of
+input stack files when we want to automatically start and stop the VTD simulator::
+
+  {
+    "version": "4",
+    "engine": {
+      "hooks": {
+        "pre_connect": [
+          { "path": "${VTD_LAUNCH}", "args": [ "stop" ] },
+          {
+            "path": "${VTD_LAUNCH}",
+            "args": [ "start", "--vtd-project", "${THIS_STACKFILE_DIR}/../contrib/projects/cloe_tests" ]
+          }
+        ],
+        "post_disconnect": [
+          { "path": "${VTD_LAUNCH}", "args": ["stop"] }
+        ]
+      }
+    }
+  }
+
+Note that we can use environment variables as well as special variables
+``THIS_STACKFILE_DIR`` and ``THIS_STACKFILE_FILE``, unless you have
+interpolation disabled. See :doc:`variables` for more information on this.
+
+Hooks can be disabled from the command line (or via an environment variable):
+
+``--no-hooks``
+    Disable execution of hooks.
+
+``--secure``, ``-s``, ``CLOE_SECURE_MODE=1``
+    Enable secure mode, which disables hooks, disables interpolation, and
+    prevents loading files from the system.
+
+See ``cloe-engine --help`` for up-to-date information for your version of
+Cloe.

--- a/docs/reference/variables.rst
+++ b/docs/reference/variables.rst
@@ -1,0 +1,66 @@
+Variable Interpolation
+======================
+
+The Cloe engine can interpolate variables of the form::
+
+    ${VARIABLE_NAME}
+    ${VARIABLE_NAME-default string}
+
+The default string can also contain a variable.
+For example, the registry path is set like so by default::
+
+    ${XDG_DATA_HOME-${HOME}/.local/share}/cloe/registry
+
+There are several special variables that are set by Cloe engine:
+
+``THIS_STACKFILE_DIR``
+    Full path to directory containing the stack file which references this variable.
+
+``THIS_STACKFILE_FILE``
+    Full path to the stack file which references this variable.
+
+``CLOE_SIMULATION_UUID``
+    If this variable is not set, then it will be automatically created for you,
+    which you can then refer to. Despite it containing the text ``UUID``, this
+    is merely a strong suggestion, and any string that is filesystem compatible
+    could be used.
+
+Example stack file::
+
+    {
+        "version": "4",
+        "engine": {
+            "output": {
+                 "path": "${THIS_STACKFILE_DIR}/output"
+            }
+        }
+    }
+
+Interpolation occurs before the JSON is parsed, so variables
+can be placed anywhere::
+
+    {
+        "version": "4",
+        ${ENGINE_CONFIG}
+    }
+
+However, care should be taken to ensure that the stack file is valid
+JSON after interpolation. In the above example, if ``ENGINE_CONFIG`` is
+empty, then the JSON is invalid, because of the trailing comma.
+
+This approach does allow us to use variables in places where strings
+are not useable, such as for integers or booleans.
+
+Interpolation can be configured from the command line,
+and the handling of non-existing variables can also be specified:
+
+``--interpolate`` and ``--no-interpolate``
+    Interpolate variables of the form ``${XYZ}`` in stack files.
+    This is enabled by default.
+
+``--interpolate-undefined``
+    Interpolate undefined variables with empty strings.
+    This is disabled by default.
+
+See ``cloe-engine --help`` for up-to-date information for your version of
+Cloe.


### PR DESCRIPTION
New:
- Enable myst_parser extensions for Sphinx markdown
- Document cloe-engine hooks
- Document cloe-engine variable interpolation

Changed:
- Move doc on actions to developer's guide
- Complete documentation on `command` action