### PR TITLE
fable: Instantiate missing Number<signed char>

### DIFF
--- a/fable/src/fable/schema/number.cpp
+++ b/fable/src/fable/schema/number.cpp
@@ -33,14 +33,15 @@ namespace fable {
 namespace schema {
 
 template class Number<char>;
+template class Number<signed char>;
 template class Number<unsigned char>;
-template class Number<short>;
+template class Number<signed short>;
 template class Number<unsigned short>;
-template class Number<int>;
+template class Number<signed int>;
 template class Number<unsigned int>;
-template class Number<long int>;
+template class Number<signed long int>;
 template class Number<unsigned long int>;
-template class Number<long long int>;
+template class Number<signed long long int>;
 template class Number<unsigned long long int>;
 template class Number<float>;
 template class Number<double>;


### PR DESCRIPTION
As it turns out, specially for char, the following is true:

    char != unsigned char
    char != signed char

Which is surprising to me. I hope that this is compatible with other compilers, otherwise this change will need some secondary patching.

---

Note: this was originally slated for 0.20.1, but that release got cancelled.