### PR TITLE
osi: Serialize OsiSensor active state

### DIFF
--- a/osi/CMakeLists.txt
+++ b/osi/CMakeLists.txt
@@ -16,6 +16,7 @@ message(STATUS "-> Building cloe-osi library.")
 file(GLOB cloe-osi_PUBLIC_HEADERS "include/**/*.hpp")
 add_library(cloe-osi
     # find src -type f -name "*.cpp" \! -name "*_test.cpp"
+    src/cloe/component/osi_sensor.cpp
     src/cloe/utility/osi_ground_truth.cpp
     src/cloe/utility/osi_message_handler.cpp
     src/cloe/utility/osi_transceiver_tcp.cpp

--- a/osi/include/cloe/component/osi_sensor.hpp
+++ b/osi/include/cloe/component/osi_sensor.hpp
@@ -23,7 +23,8 @@
 
 #include <osi3/osi_sensordata.pb.h>  // for SensorData
 
-#include <cloe/component.hpp>  // for Component
+#include <cloe/component.hpp>          // for Component, Json
+#include <cloe/utility/osi_utils.hpp>  // for osi_to_json
 
 namespace cloe {
 
@@ -41,6 +42,11 @@ class OsiSensor : public Component {
    * Return OSI-SensorData
    */
   [[nodiscard]] virtual const osi3::SensorData& get() const = 0;
+
+  /**
+   * Writes JSON representation into j.
+   */
+  fable::Json active_state() const override;
 };
 
 }  // namespace cloe

--- a/osi/include/cloe/utility/osi_utils.hpp
+++ b/osi/include/cloe/utility/osi_utils.hpp
@@ -46,6 +46,21 @@ namespace cloe::utility {
 inline Logger osi_logger() { return logger::get("vtd/osi"); }
 
 /**
+ * Serialize OSI message to a json string.
+ *
+ * Currently implemented for:
+ *
+ * - osi3::SensorData
+ * - osi3::SensorView
+ * - osi3::GroundTruth
+ *
+ * \param[in] msg OSI data to serialize
+ * \param[out] json_string string to serialize json into
+ */
+template <typename OSI_T>
+void osi_to_json(const OSI_T& msg, std::string* json_string);
+
+/**
  * Write OSI message to a .json file.
  */
 template <typename OSI_T>

--- a/osi/src/cloe/component/osi_sensor.cpp
+++ b/osi/src/cloe/component/osi_sensor.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Robert Bosch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cloe/component/osi_sensor.hpp>
+
+#include <fable/json.hpp> // for Json, parse_json
+
+namespace cloe {
+
+fable::Json OsiSensor::active_state() const {
+  std::string protobuf_json;
+  cloe::utility::osi_to_json(this->get(), &protobuf_json);
+  return fable::Json{
+    {"sensor_data", fable::parse_json(protobuf_json)}
+  };
+}
+
+}  // namespace cloe


### PR DESCRIPTION
The serialized osi message shall be available through the component interface, such that plugins like the `gndtruth_extractor` can make use of it.