### PR TITLE
vendor/open-simulation-interface: Add full_package_mode

### DIFF
--- a/vendor/open-simulation-interface/conanfile.py
+++ b/vendor/open-simulation-interface/conanfile.py
@@ -79,6 +79,9 @@ class OpenSimulationInterfaceConan(ConanFile):
         else:
             files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
+    def package_id(self):
+        self.info.requires["protobuf"].full_package_mode()
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "open_simulation_interface")
         self.cpp_info.set_property("cmake_target_name", "open_simulation_interface::open_simulation_interface")


### PR DESCRIPTION
Set full_package_mode for Protobuf to consider the case that a consumer recipe might set Protobuf as a shared or static library.

How to reproduce issue:

- Set the following options in your consumer: 'self.options['open-simulation-interface'].shared = True' and
'self.options['protobuf'].shared = True'
- Then upload the packages to artifactory.
- Now change `self.options['protobuf'].shared = False` in your consumer package.
- Try to compile again. Assuming that your Conan configuration has as default `default_package_id_mode = semver_direct_mode' then the first version of OSI produced which links to a Protobuf as shared library is installed in your Conan cache.