### PR TITLE
tooling: Disable dependabot for the UI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    # Disable version updates for npm dependencies:
+    # - It is currently unmaintained and these clutter
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "ui"


### PR DESCRIPTION
When the UI is actively developed, then Dependabot is valuable. As it is right now, we don't have capacity to test all the PRs it is making. There are three options:

1. Disable Dependabot for now.
2. Merge PRs and hope for the best.
3. Ignore PRs.

This PR implements option 1.