### PR TITLE
Cloe recipes: Fix ABI compatibility issues

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "cloe-launch"
-version = "0.24.0"
+version = "0.24.1"
 description = "Launch cloe-engine with Conan profiles."
 license = { text = "Apache-2.0" }
 authors = [

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,7 +58,6 @@ class Cloe(ConanFile):
         if self.options.with_vtd:
             cloe_requires("cloe-plugin-vtd")
 
-        boost_version = "1.74.0"
         if self.options.with_engine:
             cloe_requires("cloe-engine")
 
@@ -66,6 +65,6 @@ class Cloe(ConanFile):
         self.requires("zlib/1.2.13", override=True)
         self.requires("fmt/9.1.0", override=True)
         self.requires("inja/3.4.0", override=True)
-        self.requires("nlohmann_json/3.11.2", override=True)
-        self.requires("incbin/cci.20211107", override=True),
-        self.requires(f"boost/{boost_version}", override=True)
+        self.requires("nlohmann_json/3.11.3", override=True)
+        self.requires("incbin/cci.20211107", override=True)
+        self.requires(f"boost/1.74.0", override=True)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -58,6 +58,37 @@ readable perspective on new releases.
 
       Note that the most recent release is at the *top* of the document.
 
+0.24.1 (2024-07-23)
+-------------------
+
+This is the eighth public minor release of the Cloe packages.
+Read all about the changes :doc:`here <news/release-0.24.1>`.
+
+Please note that if you are trying to override a dependency to a different patch release, then
+the following Cloe packages will not take in consideration your override in their package_id unless
+you update to this version or you change the default configuration in your Conan config.
+
+- tooling: Align dependencies with master branch `[d4f103c] <https://github.com/eclipse/cloe/commit/d4f103c1246bb48aa0d4d94d65f3b59f2116737b>`_
+- engine: Set full_package_mode() for dependencies `[56e451f] <https://github.com/eclipse/cloe/commit/56e451fd757a1a1cb7352580bf39cfde1945fea2>`_
+- fable: Set full_package_mode() for dependencies `[35a803d] <https://github.com/eclipse/cloe/commit/35a803de06d5fa67485db60fc1f906ce5a87f80a>`_
+- models: Set full_package_mode() for dependencies `[456150f] <https://github.com/eclipse/cloe/commit/456150ff0ddcf79dbd2dbdef248e785c853e50c2>`_
+- oak: Set full_package_mode() for dependencies `[57e1011] <https://github.com/eclipse/cloe/commit/57e1011512af6cae70931420164e3122e97d6d62>`_
+- optional/vtd: Set full_package_mode() for dependencies `[44a083d] <https://github.com/eclipse/cloe/commit/44a083d654713a10133ba52b0175ec91cb19d895>`_
+- osi: Set full_package_mode() for dependencies `[439ff8e] <https://github.com/eclipse/cloe/commit/439ff8ef7e600eefb340a7df9c1c1d7518b76bf8>`_
+- plugins/basic: Set full_package_mode() for dependencies `[564f9ff] <https://github.com/eclipse/cloe/commit/564f9ff8a21f3b553095304bd60e9b1ea27a17e7>`_
+- plugins/clothoid_fit: Set full_package_mode() for dependencies `[f2651d5] <https://github.com/eclipse/cloe/commit/f2651d50d52254f7cf832be3c5d04ac9b1aa1a13>`_
+- plugins/esmini: Set full_package_mode() for dependencies `[8600619] <https://github.com/eclipse/cloe/commit/860061950a86923965c550dd8a2ba0c2ab5dd525>`_
+- plugins/frustum_culling: Set full_package_mode() for dependencies `[fe23929] <https://github.com/eclipse/cloe/commit/fe23929152654fc8ba97c2d912c170ee0ceb0c76>`_
+- plugins/gndtruth_extractor: Set full_package_mode() for dependencies `[6d13a7e] <https://github.com/eclipse/cloe/commit/6d13a7ed0966023dd907ad8f9d3f0342344b0083>`_
+- plugins/minimator: Set full_package_mode() for dependencies `[212635a] <https://github.com/eclipse/cloe/commit/212635a70b7a7d44bc158307db413b14f20c7969>`_
+- plugins/mocks: Set full_package_mode() for dependencies `[d652af4] <https://github.com/eclipse/cloe/commit/d652af4e7f42d83aec5f25920795ba5a43d831f0>`_
+- plugins/noisy_sensor: Set full_package_mode() for dependencies `[e67c81d] <https://github.com/eclipse/cloe/commit/e67c81d7948a413b20200f87afe804395acbf8dd>`_
+- plugins/speedometer: Set full_package_mode() for dependencies `[f603c11] <https://github.com/eclipse/cloe/commit/f603c115e9785ca3d757db57ecaa1cfa5329cd1e>`_
+- plugins/virtue: Set full_package_mode() for dependencies `[ffa82b0] <https://github.com/eclipse/cloe/commit/ffa82b0c90f2b19a0d02edd47dcfbfeabc6939f7>`_
+- runtime: Set full_package_mode() for dependencies `[fc1e7bd] <https://github.com/eclipse/cloe/commit/fc1e7bd69ba885d6346163bf14f50d813819516f>`_
+- vendor/esmini: Fix dependency configuration `[4e4f3f3] <https://github.com/eclipse/cloe/commit/4e4f3f3bfa5644a968cf9f7f4348cb88a749ba6d>`_
+- vendor/osi: Set full_package_mode() for dependencies `[f804d62] <https://github.com/eclipse/cloe/commit/f804d62b9235e760ce718949292edc04285e660f>`_
+
 0.24.0 (2024-05-06)
 -------------------
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -23,6 +23,7 @@ News
    :hidden:
    :maxdepth: 1
 
+   news/release-0.24.1
    news/release-0.24.0
    news/release-0.23.0
    news/release-0.22.0
@@ -30,6 +31,25 @@ News
    news/release-0.20.0
    news/release-0.19.0
 
+:doc:`Version 0.24.1 Release <news/release-0.24.1>`
+---------------------------------------------------
+
+This is a patch release to address two issues:
+
+- The open-simulation-interface and Protobuf configuration that we want to
+  support with ESMini is set to support the integration in WSL and Linux.
+  OSI is set to be compiled as a shared library and Protobuf as static. At
+  least with the current versions of OSI and Protobuf any other configuration
+  combination produces issues either in WSL or Linux.
+- Set full_package_mode() for dependencies. The Conan configuration has as
+  default semver_direct_mode. This means that from the final consumer recipe
+  perspective if I override the version of a dependency package A from v1.0.0
+  to v1.0.1, any dependency that is also part of the dependency tree and is
+  also consuming package A, will not be rebuilt because semver_direct_mode
+  doesn't consider patch releases in the package_id of the consumer. We set
+  full_package_mode to the dependencies to consider this case, the user,
+  channel and package_id of the dependencies to define the resulting package_id
+  of the consumer.
 
 :doc:`Version 0.24.0 Release <news/release-0.24.0>`
 ---------------------------------------------------

--- a/docs/news/release-0.24.1.md
+++ b/docs/news/release-0.24.1.md
@@ -1,0 +1,42 @@
+# Version 0.24.1 Release
+
+This patch release primarily fixes problems when consuming esmini simulator in Linux
+distribution under certain corner cases (in a context where more than one Conan package
+makes use of open-simulation-interface and Protobuf) and activates full_package_mode for
+all dependencies in the Cloe Conan packages.
+
+## Motivation to activate full_package_mode for the different dependencies
+
+Normally when working in a private project one wants to take advantage of distributing
+already compiled packages with a certain configuration to reduce the compile time of an
+application. Also, it happens quite often that the Conan configuration is out of your
+control (so going for a solution like changing the default configuration in the Conan
+configuration of `default_package_id_mode` from `semver_direct_mode` to something
+else is not an option). And since `semver_direct_mode` only rebuilds a package if a
+dependency is overriden to a newer minor version (it does not care about if a newer
+patch version is consumed), it might happen that from your application recipe you
+override to a newer patch version of a Conan package (let's call it `A/1.0.2`) but the
+Cloe release uploaded to your artifactory which was produced with `A/1.0.1` is still
+consumed in your build (Conan will download the packages from artifactory because,
+with the current configuration, it detects that the uploaded binaries satisfy the
+conditions to build your application). Which is wrong since you are overriding package
+`A` to be version `1.0.2` from your main recipe. If the patch release of package `A`
+is not backward compatible with its old patch version you will face runtime issues.
+To avoid this situation and to make Conan detect properly that the Cloe conan packages
+have to be rebuild with the correct overriden dependencies we calculate the package_id
+of a package setting the full_package_mode for all its dependencies. This way Conan will
+rebuild the package considering also if the version of the package changed (including
+a patch version), the user, the channel or even the package_id of the dependencies. 
+
+## Recipe fix for esmini
+
+Support to WSL and Linux distribution at the same time with open-simulation-interface and
+Protobuf is a challenge, especially due to the fact that many packages may make use of them.
+Using a different combination of how we produce the libraries will end up in runtime issues
+when we load an application using Protobuf under the hood (for example having Protobuf as
+a shared library). Using open-simulation-interface as a shared
+library and Protobuf as static library works well in both WSL and linux. This change in the
+esmini's recipe was to be more strict in which modes we use OSI and Protobuf which is actually
+what we currently support in other packages as well.
+
+

--- a/docs/reference/plugins/basic.yaml
+++ b/docs/reference/plugins/basic.yaml
@@ -1,6 +1,6 @@
 Name: basic
 Type: controller
-Path: ~/.conan/data/cloe-plugin-basic/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_basic.so
+Path: ~/.conan/data/cloe-plugin-basic/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_basic.so
 Usage: {
   "acc": "object :: ACC configuration",
   "aeb": "object :: AEB configuration",

--- a/docs/reference/plugins/basic_schema.json
+++ b/docs/reference/plugins/basic_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-basic/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_basic.so",
+  "$id": "~/.conan/data/cloe-plugin-basic/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_basic.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "very basic vehicle controller",

--- a/docs/reference/plugins/clothoid_fit.yaml
+++ b/docs/reference/plugins/clothoid_fit.yaml
@@ -1,6 +1,6 @@
 Name: clothoid_fit
 Type: component
-Path: ~/.conan/data/cloe-plugin-clothoid-fit/0.24.0/cloe/develop/package/8f9ac47c1ba762e10f909572a2501bc20131849f/lib/cloe/component_clothoid_fit.so
+Path: ~/.conan/data/cloe-plugin-clothoid-fit/0.24.1/cloe/develop/package/393a044adb3667afdbf3c814ad52113e2f3dae60/lib/cloe/component_clothoid_fit.so
 Usage: {
   "enable": "boolean :: enable or disable component",
   "frustum_culling": "boolean :: enable or disable frustum culling"

--- a/docs/reference/plugins/clothoid_fit_schema.json
+++ b/docs/reference/plugins/clothoid_fit_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-clothoid-fit/0.24.0/cloe/develop/package/8f9ac47c1ba762e10f909572a2501bc20131849f/lib/cloe/component_clothoid_fit.so",
+  "$id": "~/.conan/data/cloe-plugin-clothoid-fit/0.24.1/cloe/develop/package/393a044adb3667afdbf3c814ad52113e2f3dae60/lib/cloe/component_clothoid_fit.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "fit clothoids to polylines",

--- a/docs/reference/plugins/demo_printer.yaml
+++ b/docs/reference/plugins/demo_printer.yaml
@@ -1,5 +1,5 @@
 Name: demo_printer
 Type: controller
-Path: ~/.conan/data/cloe-plugin-mocks/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_demo_printer.so
+Path: ~/.conan/data/cloe-plugin-mocks/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_demo_printer.so
 Usage: null
 Defaults: {}

--- a/docs/reference/plugins/demo_printer_schema.json
+++ b/docs/reference/plugins/demo_printer_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-mocks/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_demo_printer.so",
+  "$id": "~/.conan/data/cloe-plugin-mocks/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_demo_printer.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "print a lot of information",

--- a/docs/reference/plugins/demo_stuck.yaml
+++ b/docs/reference/plugins/demo_stuck.yaml
@@ -1,6 +1,6 @@
 Name: demo_stuck
 Type: controller
-Path: ~/.conan/data/cloe-plugin-mocks/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_demo_stuck.so
+Path: ~/.conan/data/cloe-plugin-mocks/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_demo_stuck.so
 Usage: {
   "halt_progress_at": "integer :: time in ns at which to halt all progress",
   "progress_per_step": "integer :: progress to make each step"

--- a/docs/reference/plugins/demo_stuck_schema.json
+++ b/docs/reference/plugins/demo_stuck_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-mocks/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_demo_stuck.so",
+  "$id": "~/.conan/data/cloe-plugin-mocks/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_demo_stuck.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "slowly progressing demo controller",

--- a/docs/reference/plugins/esmini.yaml
+++ b/docs/reference/plugins/esmini.yaml
@@ -1,6 +1,6 @@
 Name: esmini
 Type: simulator
-Path: ~/.conan/data/cloe-plugin-esmini/0.24.0/cloe/develop/package/d7a7554cbdefb6329d8ab091c6c8b1679c2bb1be/lib/cloe/simulator_esmini.so
+Path: ~/.conan/data/cloe-plugin-esmini/0.24.1/cloe/develop/package/5efc0d1ed9e357b57d40f081a2edd6609cf5aa67/lib/cloe/simulator_esmini.so
 Usage: {
   "headless": "boolean :: run esmini without viewer",
   "scenario": "string :: absolute path to open scenario file",

--- a/docs/reference/plugins/esmini_schema.json
+++ b/docs/reference/plugins/esmini_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-esmini/0.24.0/cloe/develop/package/d7a7554cbdefb6329d8ab091c6c8b1679c2bb1be/lib/cloe/simulator_esmini.so",
+  "$id": "~/.conan/data/cloe-plugin-esmini/0.24.1/cloe/develop/package/5efc0d1ed9e357b57d40f081a2edd6609cf5aa67/lib/cloe/simulator_esmini.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "basic OpenScenario player",

--- a/docs/reference/plugins/frustum_culling_lanes.yaml
+++ b/docs/reference/plugins/frustum_culling_lanes.yaml
@@ -1,6 +1,6 @@
 Name: frustum_culling_lanes
 Type: component
-Path: ~/.conan/data/cloe-plugin-frustum-culling/0.24.0/cloe/develop/package/7ecda101666cc57e74197e36a88beb3d4fdbf3be/lib/cloe/component_frustum_culling_lanes.so
+Path: ~/.conan/data/cloe-plugin-frustum-culling/0.24.1/cloe/develop/package/6a34472426314ffa0c566906e297483bc1c99f10/lib/cloe/component_frustum_culling_lanes.so
 Usage: {
   "frustum": "object! :: sensor frustum",
   "reference_frame": "object! :: sensor frame of reference"

--- a/docs/reference/plugins/frustum_culling_lanes_schema.json
+++ b/docs/reference/plugins/frustum_culling_lanes_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-frustum-culling/0.24.0/cloe/develop/package/7ecda101666cc57e74197e36a88beb3d4fdbf3be/lib/cloe/component_frustum_culling_lanes.so",
+  "$id": "~/.conan/data/cloe-plugin-frustum-culling/0.24.1/cloe/develop/package/6a34472426314ffa0c566906e297483bc1c99f10/lib/cloe/component_frustum_culling_lanes.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "transform lane boundaries to given reference frame and apply frustum culling",

--- a/docs/reference/plugins/frustum_culling_objects.yaml
+++ b/docs/reference/plugins/frustum_culling_objects.yaml
@@ -1,6 +1,6 @@
 Name: frustum_culling_objects
 Type: component
-Path: ~/.conan/data/cloe-plugin-frustum-culling/0.24.0/cloe/develop/package/7ecda101666cc57e74197e36a88beb3d4fdbf3be/lib/cloe/component_frustum_culling_objects.so
+Path: ~/.conan/data/cloe-plugin-frustum-culling/0.24.1/cloe/develop/package/6a34472426314ffa0c566906e297483bc1c99f10/lib/cloe/component_frustum_culling_objects.so
 Usage: {
   "frustum": "object! :: sensor frustum",
   "reference_frame": "object! :: sensor frame of reference"

--- a/docs/reference/plugins/frustum_culling_objects_schema.json
+++ b/docs/reference/plugins/frustum_culling_objects_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-frustum-culling/0.24.0/cloe/develop/package/7ecda101666cc57e74197e36a88beb3d4fdbf3be/lib/cloe/component_frustum_culling_objects.so",
+  "$id": "~/.conan/data/cloe-plugin-frustum-culling/0.24.1/cloe/develop/package/6a34472426314ffa0c566906e297483bc1c99f10/lib/cloe/component_frustum_culling_objects.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "transform objects to given reference frame and apply frustum culling",

--- a/docs/reference/plugins/gndtruth_extractor.yaml
+++ b/docs/reference/plugins/gndtruth_extractor.yaml
@@ -1,6 +1,6 @@
 Name: gndtruth_extractor
 Type: controller
-Path: ~/.conan/data/cloe-plugin-gndtruth-extractor/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_gndtruth_extractor.so
+Path: ~/.conan/data/cloe-plugin-gndtruth-extractor/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_gndtruth_extractor.so
 Usage: {
   "components": "array of string :: array of components to be extracted",
   "output_file": "string :: file path to write groundtruth output to",

--- a/docs/reference/plugins/gndtruth_extractor_schema.json
+++ b/docs/reference/plugins/gndtruth_extractor_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-gndtruth-extractor/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_gndtruth_extractor.so",
+  "$id": "~/.conan/data/cloe-plugin-gndtruth-extractor/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_gndtruth_extractor.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "extracts information from the simulation",

--- a/docs/reference/plugins/minimator.yaml
+++ b/docs/reference/plugins/minimator.yaml
@@ -1,6 +1,6 @@
 Name: minimator
 Type: simulator
-Path: ~/.conan/data/cloe-plugin-minimator/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/simulator_minimator.so
+Path: ~/.conan/data/cloe-plugin-minimator/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/simulator_minimator.so
 Usage: {
   "vehicles": "object :: list of vehicle names to make available"
 }

--- a/docs/reference/plugins/minimator_schema.json
+++ b/docs/reference/plugins/minimator_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-minimator/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/simulator_minimator.so",
+  "$id": "~/.conan/data/cloe-plugin-minimator/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/simulator_minimator.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "minimalistic simulator",

--- a/docs/reference/plugins/noisy_lane_sensor.yaml
+++ b/docs/reference/plugins/noisy_lane_sensor.yaml
@@ -1,6 +1,6 @@
 Name: noisy_lane_sensor
 Type: component
-Path: ~/.conan/data/cloe-plugin-noisy-sensor/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/component_noisy_lane_sensor.so
+Path: ~/.conan/data/cloe-plugin-noisy-sensor/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/component_noisy_lane_sensor.so
 Usage: {
   "enable": "boolean :: enable or disable component",
   "noise": "array of object :: configure noisy parameters",

--- a/docs/reference/plugins/noisy_lane_sensor_schema.json
+++ b/docs/reference/plugins/noisy_lane_sensor_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-noisy-sensor/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/component_noisy_lane_sensor.so",
+  "$id": "~/.conan/data/cloe-plugin-noisy-sensor/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/component_noisy_lane_sensor.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "add gaussian noise to lane sensor output",

--- a/docs/reference/plugins/noisy_object_sensor.yaml
+++ b/docs/reference/plugins/noisy_object_sensor.yaml
@@ -1,6 +1,6 @@
 Name: noisy_object_sensor
 Type: component
-Path: ~/.conan/data/cloe-plugin-noisy-sensor/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/component_noisy_object_sensor.so
+Path: ~/.conan/data/cloe-plugin-noisy-sensor/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/component_noisy_object_sensor.so
 Usage: {
   "enable": "boolean :: enable or disable component",
   "noise": "array of object :: configure noisy parameters",

--- a/docs/reference/plugins/noisy_object_sensor_schema.json
+++ b/docs/reference/plugins/noisy_object_sensor_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-noisy-sensor/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/component_noisy_object_sensor.so",
+  "$id": "~/.conan/data/cloe-plugin-noisy-sensor/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/component_noisy_object_sensor.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "add gaussian noise to object sensor output",

--- a/docs/reference/plugins/speedometer.yaml
+++ b/docs/reference/plugins/speedometer.yaml
@@ -1,5 +1,5 @@
 Name: speedometer
 Type: component
-Path: ~/.conan/data/cloe-plugin-speedometer/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/component_speedometer.so
+Path: ~/.conan/data/cloe-plugin-speedometer/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/component_speedometer.so
 Usage: null
 Defaults: {}

--- a/docs/reference/plugins/speedometer_schema.json
+++ b/docs/reference/plugins/speedometer_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-speedometer/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/component_speedometer.so",
+  "$id": "~/.conan/data/cloe-plugin-speedometer/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/component_speedometer.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "provide an event trigger to evaluate speed in km/h",

--- a/docs/reference/plugins/virtue.yaml
+++ b/docs/reference/plugins/virtue.yaml
@@ -1,6 +1,6 @@
 Name: virtue
 Type: controller
-Path: ~/.conan/data/cloe-plugin-virtue/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_virtue.so
+Path: ~/.conan/data/cloe-plugin-virtue/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_virtue.so
 Usage: {
   "init_phase": "integer :: time during which initialization is performed",
   "lane_sensor_components": "array of string :: array of lane-sensor components to be checked"

--- a/docs/reference/plugins/virtue_schema.json
+++ b/docs/reference/plugins/virtue_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-virtue/0.24.0/cloe/develop/package/b604e04f9a20730e6de510c8305e28e783869866/lib/cloe/controller_virtue.so",
+  "$id": "~/.conan/data/cloe-plugin-virtue/0.24.1/cloe/develop/package/5c3bb391fe904448001b7294c2ab64c9c24ce1c5/lib/cloe/controller_virtue.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "performs various quality assurance measures",

--- a/docs/reference/plugins/vtd.yaml
+++ b/docs/reference/plugins/vtd.yaml
@@ -1,6 +1,6 @@
 Name: vtd
 Type: simulator
-Path: ~/.conan/data/cloe-plugin-vtd/0.24.0/cloe/develop/package/5bc5ec244ccb442a1db8ee83a46534971663d5e4/lib/cloe/simulator_vtd.so
+Path: ~/.conan/data/cloe-plugin-vtd/0.24.1/cloe/develop/package/a7f18fe8984f9e47fa44de4d7b79db9a8be9d7a9/lib/cloe/simulator_vtd.so
 Usage: {
   "camera": {
     "focus_on": "string :: player to focus on",

--- a/docs/reference/plugins/vtd_schema.json
+++ b/docs/reference/plugins/vtd_schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "~/.conan/data/cloe-plugin-vtd/0.24.0/cloe/develop/package/5bc5ec244ccb442a1db8ee83a46534971663d5e4/lib/cloe/simulator_vtd.so",
+  "$id": "~/.conan/data/cloe-plugin-vtd/0.24.1/cloe/develop/package/a7f18fe8984f9e47fa44de4d7b79db9a8be9d7a9/lib/cloe/simulator_vtd.so",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "VIRES Virtual Test Drive",

--- a/engine/conanfile.py
+++ b/engine/conanfile.py
@@ -101,6 +101,13 @@ class CloeEngine(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
+        self.info.requires["cli11"].full_package_mode()
+        if self.options.server:
+            self.info.requires["cloe-oak"].full_package_mode()
+        self.info.requires["fmt"].full_package_mode()
+        self.info.requires["nlohmann_json"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/fable/conanfile.py
+++ b/fable/conanfile.py
@@ -89,6 +89,10 @@ class Fable(ConanFile):
         if self.should_install:
             cm.install()
 
+    def package_id(self):
+        self.info.requires["nlohmann_json"].full_package_mode()
+        self.info.requires["fmt"].full_package_mode()
+
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "fable")

--- a/models/conanfile.py
+++ b/models/conanfile.py
@@ -73,7 +73,9 @@ class CloeModels(ConanFile):
             cm.install()
 
     def package_id(self):
+        self.info.requires["cloe-runtime"].full_package_mode()
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["eigen"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/oak/conanfile.py
+++ b/oak/conanfile.py
@@ -72,6 +72,8 @@ class CloeOak(ConanFile):
             cm.install()
 
     def package_id(self):
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["oatpp"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/optional/vtd/conanfile.py
+++ b/optional/vtd/conanfile.py
@@ -54,7 +54,7 @@ class CloeSimulatorVTD(ConanFile):
         self.requires("fmt/9.1.0", override=True)
         self.requires("inja/3.4.0", override=True)
         self.requires("nlohmann_json/3.11.2", override=True)
-        self.requires("incbin/cci.20211107", override=True),
+        self.requires("incbin/cci.20211107", override=True)
 
     def build_requirements(self):
         self.test_requires("gtest/1.13.0")
@@ -135,6 +135,7 @@ class CloeSimulatorVTD(ConanFile):
         self.info.requires["open-simulation-interface"].full_package_mode()
         self.info.requires["vtd-api"].full_package_mode()
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["nlohmann_json"].full_package_mode()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/osi/conanfile.py
+++ b/osi/conanfile.py
@@ -78,6 +78,10 @@ class CloeOsi(ConanFile):
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
         self.info.requires["open-simulation-interface"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["eigen"].full_package_mode()
+        self.info.requires["zlib"].full_package_mode()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/plugins/basic/conanfile.py
+++ b/plugins/basic/conanfile.py
@@ -71,6 +71,8 @@ class CloeControllerBasic(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/plugins/clothoid_fit/conanfile.py
+++ b/plugins/clothoid_fit/conanfile.py
@@ -62,6 +62,9 @@ class CloeComponentClothoidFit(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["eigen"].full_package_mode()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/plugins/esmini/conanfile.py
+++ b/plugins/esmini/conanfile.py
@@ -61,6 +61,14 @@ class CloeSimulatorESMini(ConanFile):
         if self.should_install:
             cm.install()
 
+    def package_id(self):
+        self.info.requires["cloe-models"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["eigen"].full_package_mode()
+        self.info.requires["zlib"].full_package_mode()
+        self.info.requires["esmini"].full_package_mode()
+        self.info.requires["cloe-osi"].full_package_mode()
+
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", self.name)

--- a/plugins/frustum_culling/conanfile.py
+++ b/plugins/frustum_culling/conanfile.py
@@ -72,7 +72,11 @@ class CloeComponentFrustumCulling(ConanFile):
             cm.install()
 
     def package_id(self):
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
+        self.info.requires["fmt"].full_package_mode()
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["nlohmann_json"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/plugins/gndtruth_extractor/conanfile.py
+++ b/plugins/gndtruth_extractor/conanfile.py
@@ -70,6 +70,8 @@ class CloeControllerGndtruthExtractor(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/plugins/minimator/conanfile.py
+++ b/plugins/minimator/conanfile.py
@@ -71,6 +71,8 @@ class CloeSimulatorMinimator(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/plugins/mocks/conanfile.py
+++ b/plugins/mocks/conanfile.py
@@ -65,6 +65,8 @@ class CloeControllerMocks(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/plugins/noisy_sensor/conanfile.py
+++ b/plugins/noisy_sensor/conanfile.py
@@ -70,6 +70,8 @@ class CloeComponentNoisySensor(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/plugins/speedometer/conanfile.py
+++ b/plugins/speedometer/conanfile.py
@@ -65,6 +65,8 @@ class CloeComponentKmph(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/plugins/virtue/conanfile.py
+++ b/plugins/virtue/conanfile.py
@@ -65,6 +65,8 @@ class CloeControllerVirtue(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["cloe-runtime"].full_package_mode()
+        self.info.requires["cloe-models"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/runtime/conanfile.py
+++ b/runtime/conanfile.py
@@ -90,6 +90,10 @@ class CloeRuntime(ConanFile):
 
     def package_id(self):
         self.info.requires["boost"].full_package_mode()
+        self.info.requires["fable"].full_package_mode()
+        self.info.requires["inja"].full_package_mode()
+        self.info.requires["spdlog"].full_package_mode()
+        self.info.requires["incbin"].full_package_mode()
         del self.info.options.pedantic
 
     def package_info(self):

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloe-ui",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "cloe-compatibility": "0.16",
   "license": "Apache-2.0",
   "private": true,

--- a/ui/server/package.json
+++ b/ui/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloe-ui-server",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "cloe-compatibility": "0.18",
   "license": "Apache-2.0",
   "private": true,

--- a/vendor/esmini/conanfile.py
+++ b/vendor/esmini/conanfile.py
@@ -38,11 +38,10 @@ class ESMini(ConanFile):
     def configure(self):
         if self.options.with_osg:
             self.options.with_osi = True
-        if self.options.with_osi:
-            self.options["open-simulation-interface"].shared = self.options.shared
-            self.options["protobuf"].shared = True
-        self.options["open-simulation-interface"].shared = self.options.shared
-        self.options["protobuf"].shared = self.options.shared
+        # Note: we use the following combination for OSI and Protobuf to avoid runtime
+        # issues either in WSL or Linux.
+        self.options["open-simulation-interface"].shared = True
+        self.options["protobuf"].shared = False
 
     def layout(self):
         # We can't use cmake_layout because ESmini *really* doesn't like stuff to
@@ -158,6 +157,9 @@ class ESMini(ConanFile):
             src=os.path.join(self.source_folder, "3rd_party_terms_and_licenses"),
             dst=os.path.join(self.package_folder, "licenses"),
         )
+
+    def package_id(self):
+        self.info.requires["open-simulation-interface"].full_package_mode()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "esmini")

--- a/vendor/open-simulation-interface/conanfile.py
+++ b/vendor/open-simulation-interface/conanfile.py
@@ -79,6 +79,9 @@ class OpenSimulationInterfaceConan(ConanFile):
         else:
             files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
+    def package_id(self):
+        self.info.requires["protobuf"].full_package_mode()
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "open_simulation_interface")
         self.cpp_info.set_property("cmake_target_name", "open_simulation_interface::open_simulation_interface")


### PR DESCRIPTION
- Changes shall be released as Cloe v0.24.1.
- Add full_package_mode() to dependencies. Conan configuration default parameter is semver_direct_mode. This means that only a package will be rebuilt when the consumer changes the package version to a newer major version. For example, if consumed nlohmann_json/3.11.2 is consumed by fable/, but the final application recipe overrides nlohmann_json/3.11.3, with the default Conan configuration, fable won't be rebuilt causing a runtime error due to ABI incompatibility. Most of the times the Conan configuration in a project is not under our control making it impossible to change this from the Conan configuration side. Hence, having the recipes with the mode that we want becomes important.
- Fix shared option value for OSI and Protobuf when consumed in esmini conan package. The OSI.shared=True and protobuf.shared=False is set on purpose to avoid runtime issues with Protobuf with either WSL or Linux (different values will produce runtime issues).